### PR TITLE
Slate Struct

### DIFF
--- a/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
+++ b/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
@@ -1,0 +1,74 @@
+package org.sparkle
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.param.{Param, ParamMap}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructType}
+import org.sparkle.slate._
+
+class SparkleSlateExtractorTransformer(override val uid: String) extends Transformer {
+  def this() = this(Identifiable.randomUID("sparkler_slate_extractor"))
+
+  //@transient private var pipeline: StringAnalysisFunction = _
+
+  val pipeline: Param[StringAnalysisFunction] = new Param(this, "pipeline", "a pipeline which consumes a Slate structure and produces a Slate structure with resulting analysis")
+
+  def getPipeline: StringAnalysisFunction = $(pipeline)
+
+  def setPipeline(value: StringAnalysisFunction): this.type = set(pipeline, value)
+
+  val textCol: Param[String] = new Param(this, "textCol", "name of column containing text to be analyzed")
+
+  def getTextCol: String = $(textCol)
+
+  def setTextCol(value: String): this.type = set(textCol, value)
+
+  val extractors: Param[Seq[Tuple2[String, StringSlateExtractor]]] = new Param(this, "extractors",
+    "Map of outputColumns and their StringSlateExtractor function objects")
+
+  @transient val combinedExtractorUdf = udf((text:String) => {
+    val slate = Slate(text)
+    val x = for ((key, extractor) <- $(extractors)) yield (key, extractor(slate))
+    x.toMap
+  })
+
+
+  /*
+  def runExtractors2(df: DataFrame, slate: StringSlate, extractorsToRun: Seq[Tuple2[String, StringSlateExtractor]]): DataFrame = {
+    extractorsToRun match {
+      case Nil => df
+      case (outputCol, extractor)::remainingExtractors => {
+        val func = udf(()=>extractor(slate))
+        runExtractors(df.withColumn(outputCol, func()), slate, remainingExtractors)
+      }
+    }
+    df
+  }
+  */
+
+  def extractMapToColumns(df: DataFrame, mapColName: String, colNames: Seq[String]): DataFrame = colNames match {
+    case Nil => df
+    case colName::remaining => extractMapToColumns(
+      df.withColumn(colName, col(s"$mapColName.$colName")), mapColName, remaining)
+    case _ => df
+  }
+
+  override def transform(dataset: DataFrame): DataFrame =  {
+    val tmpColName = s"{this.uid}_tmp"
+    val colNames = $(extractors).map(_._1)
+
+    // Run pipeline and extractors UDF  on text column
+    val df = dataset.withColumn(tmpColName, combinedExtractorUdf(col($(textCol))))
+    // Now pull out data from map structure into separate columns
+    extractMapToColumns(df, tmpColName, colNames).drop(tmpColName)
+  }
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+
+  @DeveloperApi
+  override def transformSchema(schema: StructType): StructType = ???
+}
+

--- a/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
+++ b/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
@@ -5,24 +5,28 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.{DataFrame, UserDefinedFunction}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, UserDefinedFunction}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.sparkle.slate._
 
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 
-class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) extends Transformer {
+class SparkleSlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) extends Transformer {
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor"))
 
-  //@transient private var pipeline: StringAnalysisFunction = _
 
   val pipeline: Param[StringAnalysisFunction] = new Param(this, "pipeline", "a pipeline which consumes a Slate structure and produces a Slate structure with resulting analysis")
 
   def getPipeline: StringAnalysisFunction = $(pipeline)
 
   def setPipeline(value: StringAnalysisFunction): this.type = set(pipeline, value)
+
+  //@transient var pipeline: StringAnalysisFunction = _
+  lazy val pipelineObj = getPipeline
 
   val textCol: Param[String] = new Param(this, "textCol", "name of column containing text to be analyzed")
 
@@ -39,10 +43,8 @@ class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) ext
 
   def setExtractors1(value: Seq[ExtractorsType1]): this.type = set("extractors1", value)
 
-
+  /*
   lazy val comboUdf1 = generateUdf($(extractors1))
-
-    //generateUdf($(extractors))
 
   def generateUdf[T:TypeTag](extractorList: Seq[Tuple2[String, StringSlateExtractor[T]]]) = {
     val f = (text: String) => {
@@ -52,21 +54,6 @@ class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) ext
     }
     udf((text: String) => f)
   }
-/*{
-      val slate = Slate(text)
-      val x = for ((key, extractor) <- extractorList) yield (key, extractor(slate))
-      x.toMap[String, T1]
-    })
-  }
-    */
-
-
-  /*
-  @transient val combinedExtractorUdf = udf((text:String) => {
-    val slate = Slate(text)
-    val x = for ((key, extractor) <- $(extractors)) yield (key, extractor(slate))
-    x.toMap
-  })
   */
 
   /* this is not possible because we do not have access to the text until it is in the UDF, so there is no way to propagage
@@ -89,14 +76,46 @@ class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) ext
     case _ => df
   }
 
+  def makeZip(s: Seq[RDD[_]]): RDD[Seq[_]] = {
+    if (s.length == 1)
+      s.head.map(e => Seq(e))
+    else {
+      val others = makeZip(s.tail)
+      val all = s.head.zip(others)
+      all.map(elem => Seq(elem._1) ++ elem._2)
+    }
+  }
+
   override def transform(dataset: DataFrame): DataFrame =  {
     val tmpColName = s"{this.uid}_tmp"
     val colNames = $(extractors1).map(_._1)
 
+    import org.apache.spark.sql.catalyst.ScalaReflection
+    val datasetRdd = dataset.rdd
+    val textRdd = dataset.select(col($(textCol))).map(_.getAs[String](0))
+    val slateInRdd = textRdd.map(Slate(_))
+    @transient val slateOutRdd = slateInRdd.map(org.sparkle.clearnlp.SentenceSegmenterAndTokenizer(_))
+
+      //pipelineObj(_))
+    val schema1 = ScalaReflection.schemaFor[T1].dataType
+
+    val schemaAndColumn = for ((extractorName, extractor) <- $(extractors1))
+      yield (StructField(extractorName, schema1),  slateOutRdd.map(slate => extractor(slate)))
+
+    val columns = makeZip(schemaAndColumn.map(_._2))
+    val schemas = schemaAndColumn.map(_._1)
+    val schema = StructType(dataset.schema ++ schemas)
+    val datasetWithExtractor1Rdd = datasetRdd.zip(columns).map{case (rows, newCols) => Row(rows.toSeq ++ newCols: _*)}
+    import dataset.sqlContext.implicits._
+    dataset.sqlContext.createDataFrame(datasetWithExtractor1Rdd, schema)
+
+
+    /*
     // Run pipeline and extractors UDF  on text column
     val df = dataset.withColumn(tmpColName, comboUdf1(col($(textCol))))
     // Now pull out data from map structure into separate columns
     extractMapToColumns(df, tmpColName, colNames).drop(tmpColName)
+    */
   }
 
   override def copy(extra: ParamMap): org.apache.spark.ml.Transformer = defaultCopy(extra)
@@ -105,3 +124,29 @@ class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) ext
   override def transformSchema(schema: StructType): StructType = ???
 }
 
+//// DAMMIT DAMMIT DAMMIT.. this won't work because it reruns the slate generation.
+//class SparkleSlateExtractorTransformer2[T1:TypeTag, T2:TypeTag](override val uid: String) extends SparkleSlateExtractorTransformer[T1] {
+//  type ExtractorsType2 = Tuple2[String, StringSlateExtractor[T2]]
+//
+//  val extractors2: Param[Seq[ExtractorsType1]] = new Param(this, "extractors1",
+//    "Map of outputColumns and their StringSlateExtractor function objects")
+//
+//  def getExtractors2: Seq[ExtractorsType1] = $(extractors2)
+//
+//  def setExtractors2(value: Seq[ExtractorsType1]): this.type = set("extractors1", value)
+//
+//  /*
+//  lazy val comboUdf2 = generateUdf($(extractors2))
+//  override def transform(dataset: DataFrame): DataFrame =  {
+//    val tmpColName = s"{this.uid}_tmp2"
+//    val colNames = $(extractors2).map(_._1)
+//
+//    super.transform(dataset)
+//    val df = super.transform(dataset).
+//      withColumn(tmpColName, comboUdf2(col($(textCol))))
+//    // Now pull out data from map structure into separate columns
+//    extractMapToColumns(df, tmpColName, colNames).drop(tmpColName)
+//
+//  }
+//  */
+//}

--- a/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
+++ b/src/main/scala/org/sparkle/SparkleSlateExtractorTransformer.scala
@@ -1,15 +1,19 @@
 package org.sparkle
 
+import org.apache.poi.ss.formula.functions.T
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, UserDefinedFunction}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{StructType}
+import org.apache.spark.sql.types.StructType
 import org.sparkle.slate._
 
-class SparkleSlateExtractorTransformer(override val uid: String) extends Transformer {
+import scala.reflect.runtime.universe._
+
+
+class SparkleSlateExtractorTransformer[T1:TypeTag](override val uid: String) extends Transformer {
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor"))
 
   //@transient private var pipeline: StringAnalysisFunction = _
@@ -26,18 +30,47 @@ class SparkleSlateExtractorTransformer(override val uid: String) extends Transfo
 
   def setTextCol(value: String): this.type = set(textCol, value)
 
-  val extractors: Param[Seq[Tuple2[String, StringSlateExtractor]]] = new Param(this, "extractors",
+  type ExtractorsType1 = Tuple2[String, StringSlateExtractor[T1]]
+
+  val extractors1: Param[Seq[ExtractorsType1]] = new Param(this, "extractors1",
     "Map of outputColumns and their StringSlateExtractor function objects")
 
+  def getExtractors1: Seq[ExtractorsType1] = $(extractors1)
+
+  def setExtractors1(value: Seq[ExtractorsType1]): this.type = set("extractors1", value)
+
+
+  lazy val comboUdf1 = generateUdf($(extractors1))
+
+    //generateUdf($(extractors))
+
+  def generateUdf[T:TypeTag](extractorList: Seq[Tuple2[String, StringSlateExtractor[T]]]) = {
+    val f = (text: String) => {
+      val slate = Slate(text)
+      val x = for ((key, extractor) <- extractorList) yield (key, extractor(slate))
+      x
+    }
+    udf((text: String) => f)
+  }
+/*{
+      val slate = Slate(text)
+      val x = for ((key, extractor) <- extractorList) yield (key, extractor(slate))
+      x.toMap[String, T1]
+    })
+  }
+    */
+
+
+  /*
   @transient val combinedExtractorUdf = udf((text:String) => {
     val slate = Slate(text)
     val x = for ((key, extractor) <- $(extractors)) yield (key, extractor(slate))
     x.toMap
   })
+  */
 
-
-  /*
-  def runExtractors2(df: DataFrame, slate: StringSlate, extractorsToRun: Seq[Tuple2[String, StringSlateExtractor]]): DataFrame = {
+  /* this is not possible because we do not have access to the text until it is in the UDF, so there is no way to propagage
+  def runExtractors[T](df: DataFrame, slate: StringSlate, extractorsToRun: Seq[Tuple2[String, StringSlateExtractor[T]]]): DataFrame = {
     extractorsToRun match {
       case Nil => df
       case (outputCol, extractor)::remainingExtractors => {
@@ -58,15 +91,15 @@ class SparkleSlateExtractorTransformer(override val uid: String) extends Transfo
 
   override def transform(dataset: DataFrame): DataFrame =  {
     val tmpColName = s"{this.uid}_tmp"
-    val colNames = $(extractors).map(_._1)
+    val colNames = $(extractors1).map(_._1)
 
     // Run pipeline and extractors UDF  on text column
-    val df = dataset.withColumn(tmpColName, combinedExtractorUdf(col($(textCol))))
+    val df = dataset.withColumn(tmpColName, comboUdf1(col($(textCol))))
     // Now pull out data from map structure into separate columns
     extractMapToColumns(df, tmpColName, colNames).drop(tmpColName)
   }
 
-  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): org.apache.spark.ml.Transformer = defaultCopy(extra)
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = ???

--- a/src/main/scala/org/sparkle/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/StringSlateExtractor.scala
@@ -17,13 +17,12 @@ trait StringSlateExtractor[SCHEMA] {
 
 //object FooExtractor(flattener: String) extends StringSlateExtractor with Serializable {
 
-object TokenCountExtractor extends StringSlateExtractor {
+object TokenCountExtractor extends StringSlateExtractor[Int] {
   override def apply(slate: StringSlate): Int = slate.iterator[Token].size
 }
 
-class
 
-object DumbExtractor extends StringSlateExtractor {
+object DumbExtractor extends StringSlateExtractor[(String, String)]{
   import org.apache.spark.sql.functions._
 
   override def apply(slate: StringSlate) = Tuple2("y", "string")
@@ -31,14 +30,14 @@ object DumbExtractor extends StringSlateExtractor {
 }
 
 
+case class SentenceSchema(beginIndex: Int, endIndex: Int, tokens: Seq[TokenSchema])
 
-object NestedExtractor extends StringSlateExtractor {
+case class TokenSchema(token: String, pos: String, beginIndex: Int, endIndex: Int)
 
-  case class SentenceSchema(beginIndex: Int, endIndex: Int, tokens: Seq[TokenSchema])
+case class ResultSchema(text: String, sentences: Seq[SentenceSchema])
 
-  case class TokenSchema(token: String, pos: String, beginIndex: Int, endIndex: Int)
 
-  case class ResultSchema(text: String, sentences: Seq[SentenceSchema])
+object NestedExtractor extends StringSlateExtractor[ResultSchema] {
 
   def apply(slate: StringSlate) = {
 

--- a/src/main/scala/org/sparkle/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/StringSlateExtractor.scala
@@ -17,7 +17,7 @@ trait StringSlateExtractor[SCHEMA] {
 
 //object FooExtractor(flattener: String) extends StringSlateExtractor with Serializable {
 
-object TokenCountExtractor extends StringSlateExtractor[Int] {
+object TokenCountExtractor extends StringSlateExtractor[Int] with Serializable{
   override def apply(slate: StringSlate): Int = slate.iterator[Token].size
 }
 
@@ -37,7 +37,7 @@ case class TokenSchema(token: String, pos: String, beginIndex: Int, endIndex: In
 case class ResultSchema(text: String, sentences: Seq[SentenceSchema])
 
 
-object NestedExtractor extends StringSlateExtractor[ResultSchema] {
+object NestedExtractor extends StringSlateExtractor[ResultSchema] with Serializable {
 
   def apply(slate: StringSlate) = {
 

--- a/src/main/scala/org/sparkle/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/StringSlateExtractor.scala
@@ -1,7 +1,6 @@
 package org.sparkle
 
 import epic.slab.Sentence
-import org.apache.spark.sql.types._
 import org.sparkle.slate.{Span, StringSlate}
 import org.sparkle.typesystem.basic.Token
 
@@ -11,22 +10,12 @@ import org.sparkle.typesystem.basic.Token
 /**
   * Created by leebecker on 4/14/16.
   */
-trait StringSlateExtractor[SCHEMA] {
+trait StringSlateExtractor[SCHEMA] extends Serializable {
   def apply(slate: StringSlate): SCHEMA
 }
 
-//object FooExtractor(flattener: String) extends StringSlateExtractor with Serializable {
-
-object TokenCountExtractor extends StringSlateExtractor[Int] with Serializable{
+object TokenCountExtractor extends StringSlateExtractor[Int] {
   override def apply(slate: StringSlate): Int = slate.iterator[Token].size
-}
-
-
-object DumbExtractor extends StringSlateExtractor[(String, String)]{
-  import org.apache.spark.sql.functions._
-
-  override def apply(slate: StringSlate) = Tuple2("y", "string")
-
 }
 
 

--- a/src/main/scala/org/sparkle/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/StringSlateExtractor.scala
@@ -1,0 +1,62 @@
+package org.sparkle
+
+import epic.slab.Sentence
+import org.apache.spark.sql.types._
+import org.sparkle.slate.{Span, StringSlate}
+import org.sparkle.typesystem.basic.Token
+
+
+
+
+/**
+  * Created by leebecker on 4/14/16.
+  */
+trait StringSlateExtractor[SCHEMA] {
+  def apply(slate: StringSlate): SCHEMA
+}
+
+//object FooExtractor(flattener: String) extends StringSlateExtractor with Serializable {
+
+object TokenCountExtractor extends StringSlateExtractor {
+  override def apply(slate: StringSlate): Int = slate.iterator[Token].size
+}
+
+class
+
+object DumbExtractor extends StringSlateExtractor {
+  import org.apache.spark.sql.functions._
+
+  override def apply(slate: StringSlate) = Tuple2("y", "string")
+
+}
+
+
+
+object NestedExtractor extends StringSlateExtractor {
+
+  case class SentenceSchema(beginIndex: Int, endIndex: Int, tokens: Seq[TokenSchema])
+
+  case class TokenSchema(token: String, pos: String, beginIndex: Int, endIndex: Int)
+
+  case class ResultSchema(text: String, sentences: Seq[SentenceSchema])
+
+  def apply(slate: StringSlate) = {
+
+    val spansAndSentences = slate.iterator[Sentence].toList
+
+    val sentenceStructs = spansAndSentences.map {
+      case (sentenceSpan, sentence) => {
+        val (spansAndTokens) = slate.covered[Token](sentenceSpan)
+
+        val tokens = spansAndTokens.map {
+          case (tokenSpan, token) => TokenSchema(token.token, token.pos.getOrElse(null), tokenSpan.begin, tokenSpan.end)
+        }
+        SentenceSchema(sentenceSpan.begin, sentenceSpan.end, tokens)
+      }
+    }
+    ResultSchema(text = slate.content, sentences = sentenceStructs)
+
+  }
+}
+
+

--- a/src/main/scala/org/sparkle/clearnlp/DependencyParser.scala
+++ b/src/main/scala/org/sparkle/clearnlp/DependencyParser.scala
@@ -5,8 +5,7 @@ import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.{DEPFeat, DEPNode, DEPTree}
 import edu.emory.clir.clearnlp.util.lang.TLanguage
 import org.sparkle.slate._
-import epic.slab.Sentence
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.{Sentence,Token}
 import org.sparkle.typesystem.syntax.dependency._
 
 import scala.collection.JavaConversions._

--- a/src/main/scala/org/sparkle/clearnlp/DependencyParser.scala
+++ b/src/main/scala/org/sparkle/clearnlp/DependencyParser.scala
@@ -4,8 +4,8 @@ import edu.emory.clir.clearnlp.component.mode.dep.DEPConfiguration
 import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.{DEPFeat, DEPNode, DEPTree}
 import edu.emory.clir.clearnlp.util.lang.TLanguage
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Sentence
 import org.sparkle.typesystem.basic.{Token}
 import org.sparkle.typesystem.syntax.dependency._
 
@@ -18,7 +18,7 @@ import scala.collection.mutable
   * Prerequisites: Slab object with Sentence and Token annotations <br>
   * Outputs: new Slab object with Sentence and Tokens with pos field set <br>
   */
-object DependencyParser extends StringAnalysisFunction[Sentence with Token, DependencyNode with DependencyRelation] with Serializable {
+object DependencyParser extends StringAnalysisFunction with Serializable {
   val defaultLanguageCode = TLanguage.ENGLISH.toString
   val mpAnalyzer = NLPUtils.getMPAnalyzer(TLanguage.getType(defaultLanguageCode))
   val parserModelPath = "general-en-dep.xz"
@@ -27,7 +27,7 @@ object DependencyParser extends StringAnalysisFunction[Sentence with Token, Depe
   GlobalLexica.initDistributionalSemanticsWords(paths)
   val parser = NLPUtils.getDEPParser(TLanguage.getType(defaultLanguageCode), parserModelPath, new DEPConfiguration("root"))
 
-  def apply[In <: Token with Sentence](slab: StringSlab[In]): StringSlab[In with DependencyNode with DependencyRelation] = {
+  def apply(slab: StringSlate): StringSlate = {
     val depGraphSpans = slab.iterator[Sentence].map {
       case (sentenceSpan, sentence) =>
         val tokens = slab.covered[Token](sentenceSpan).seq

--- a/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
+++ b/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
@@ -4,8 +4,8 @@ package org.sparkle.clearnlp
 import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.DEPTree
 import edu.emory.clir.clearnlp.util.lang.TLanguage
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Sentence
 import org.sparkle.typesystem.basic.{Token}
 
 import scala.collection.JavaConversions._
@@ -17,11 +17,11 @@ import scala.collection.JavaConverters._
   * Prerequisites: Slab object with Sentence and Token annotations <br>
   * Outputs: new Slab object with Sentence and Tokens with pos field set <br>
   */
-object MpAnalyzer extends StringAnalysisFunction[Sentence with Token, Token] with Serializable {
+object MpAnalyzer extends StringAnalysisFunction with Serializable {
   val defaultLanguageCode = TLanguage.ENGLISH.toString
   val mpAnalyzer = NLPUtils.getMPAnalyzer(TLanguage.getType(defaultLanguageCode));
 
-  def apply[In <: Token with Sentence](slab: StringSlab[In]): StringSlab[In with Token] =  {
+  def apply(slab: StringSlate): StringSlate =  {
     val lemmatizedTaggedTokenSpans = slab.iterator[Sentence].flatMap{
       case(sentenceSpan, _) =>
         val tokens = slab.covered[Token](sentenceSpan)

--- a/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
+++ b/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
@@ -5,8 +5,7 @@ import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.DEPTree
 import edu.emory.clir.clearnlp.util.lang.TLanguage
 import org.sparkle.slate._
-import epic.slab.Sentence
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._

--- a/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
+++ b/src/main/scala/org/sparkle/clearnlp/MpAnalyzer.scala
@@ -13,18 +13,18 @@ import scala.collection.JavaConverters._
 /**
   * SparkLE wrapper for ClearNLP MpAnalyzer<p>
   *
-  * Prerequisites: Slab object with Sentence and Token annotations <br>
-  * Outputs: new Slab object with Sentence and Tokens with pos field set <br>
+  * Prerequisites: Slate object with Sentence and Token annotations <br>
+  * Outputs: new Slate object with Sentence and Tokens with pos field set <br>
   */
 object MpAnalyzer extends StringAnalysisFunction with Serializable {
   val defaultLanguageCode = TLanguage.ENGLISH.toString
   val mpAnalyzer = NLPUtils.getMPAnalyzer(TLanguage.getType(defaultLanguageCode));
 
-  def apply(slab: StringSlate): StringSlate =  {
-    val lemmatizedTaggedTokenSpans = slab.iterator[Sentence].flatMap{
+  def apply(slate: StringSlate): StringSlate =  {
+    val lemmatizedTaggedTokenSpans = slate.iterator[Sentence].flatMap{
       case(sentenceSpan, _) =>
-        val tokens = slab.covered[Token](sentenceSpan)
-        val tokenStrings = tokens.map { case (tokenSpan, _) => slab.spanned(tokenSpan) }
+        val tokens = slate.covered[Token](sentenceSpan)
+        val tokenStrings = tokens.map { case (tokenSpan, _) => slate.spanned(tokenSpan) }
 
         // Run ClearNLP pos tagger
         val clearNlpDepTree = new DEPTree(tokenStrings)
@@ -38,9 +38,9 @@ object MpAnalyzer extends StringAnalysisFunction with Serializable {
         }
     }
 
-    // Remove old tokens and add new pos-tagged ones to slab
+    // Remove old tokens and add new pos-tagged ones to slate
     // FIXME - potentially dangerous if operating over specialized windows
-    val res = slab.removeLayer[Token].addLayer[Token](lemmatizedTaggedTokenSpans)
+    val res = slate.removeLayer[Token].addLayer[Token](lemmatizedTaggedTokenSpans)
     res
   }
 

--- a/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
+++ b/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
@@ -5,8 +5,7 @@ import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.DEPTree
 import edu.emory.clir.clearnlp.util.lang.TLanguage
 import org.sparkle.slate._
-import epic.slab.Sentence
-import org.sparkle.typesystem.basic.Token
+import org.sparkle.typesystem.basic.{Sentence,Token}
 import org.sparkle.typesystem.ops._
 
 import scala.collection.JavaConversions._
@@ -60,9 +59,9 @@ class PosTaggerWithSparkleTypes(languageCode: String, modelPath: String, paths: 
 
 
 class PosTaggerWithEpicTypes(languageCode: String, modelPath: String, paths: Seq[String])
-  extends PosTaggerImplBase[Sentence, epic.slab.Token, epic.slab.PartOfSpeech](languageCode, modelPath, paths) {
+  extends PosTaggerImplBase[epic.slab.Sentence, epic.slab.Token, epic.slab.PartOfSpeech](languageCode, modelPath, paths) {
 
-  override val sentenceOps: SentenceOps[Sentence] = EpicSentenceOps
+  override val sentenceOps: SentenceOps[epic.slab.Sentence] = EpicSentenceOps
   override val tokenOps: TokenOps[epic.slab.Token] = EpicTokenOps
   override val posTagOps: PartOfSpeechOps[epic.slab.Token, epic.slab.PartOfSpeech] = EpicPartOfSpeechOps
 }

--- a/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
+++ b/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
@@ -4,8 +4,8 @@ import edu.emory.clir.clearnlp.component.mode.pos.AbstractPOSTagger
 import edu.emory.clir.clearnlp.component.utils.{GlobalLexica, NLPUtils}
 import edu.emory.clir.clearnlp.dependency.DEPTree
 import edu.emory.clir.clearnlp.util.lang.TLanguage
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Sentence
 import org.sparkle.typesystem.basic.Token
 import org.sparkle.typesystem.ops._
 
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
 
 abstract class PosTaggerImplBase[SENTENCE, TOKEN, POSTAG](
     languageCode: String, modelPath: String, paths: Seq[String])
-  extends StringAnalysisFunction[SENTENCE with TOKEN, TOKEN] with Serializable {
+  extends StringAnalysisFunction with Serializable {
 
   val sentenceOps: SentenceOps[SENTENCE]
   val tokenOps: TokenOps[TOKEN]
@@ -26,7 +26,7 @@ abstract class PosTaggerImplBase[SENTENCE, TOKEN, POSTAG](
   def getTagger(): AbstractPOSTagger = tagger
 
   override
-  def apply[In <: SENTENCE with TOKEN](slab: StringSlab[In]): StringSlab[In with POSTAG] = {
+  def apply(slab: StringSlate): StringSlate = {
     val posTaggedTokenSpans = sentenceOps.selectAllSentences(slab).flatMap{
       case (sentenceSpan, sentence) =>
         val tokens = tokenOps.selectTokens(slab, sentenceSpan).toIndexedSeq
@@ -60,11 +60,11 @@ class PosTaggerWithSparkleTypes(languageCode: String, modelPath: String, paths: 
 
 
 class PosTaggerWithEpicTypes(languageCode: String, modelPath: String, paths: Seq[String])
-  extends PosTaggerImplBase[Sentence, epic.slab.Token, PartOfSpeech](languageCode, modelPath, paths) {
+  extends PosTaggerImplBase[Sentence, epic.slab.Token, epic.slab.PartOfSpeech](languageCode, modelPath, paths) {
 
   override val sentenceOps: SentenceOps[Sentence] = EpicSentenceOps
   override val tokenOps: TokenOps[epic.slab.Token] = EpicTokenOps
-  override val posTagOps: PartOfSpeechOps[epic.slab.Token, PartOfSpeech] = EpicPartOfSpeechOps
+  override val posTagOps: PartOfSpeechOps[epic.slab.Token, epic.slab.PartOfSpeech] = EpicPartOfSpeechOps
 }
 
 

--- a/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
+++ b/src/main/scala/org/sparkle/clearnlp/PosTagger.scala
@@ -25,11 +25,11 @@ abstract class PosTaggerImplBase[SENTENCE, TOKEN, POSTAG](
   def getTagger(): AbstractPOSTagger = tagger
 
   override
-  def apply(slab: StringSlate): StringSlate = {
-    val posTaggedTokenSpans = sentenceOps.selectAllSentences(slab).flatMap{
+  def apply(slate: StringSlate): StringSlate = {
+    val posTaggedTokenSpans = sentenceOps.selectAllSentences(slate).flatMap{
       case (sentenceSpan, sentence) =>
-        val tokens = tokenOps.selectTokens(slab, sentenceSpan).toIndexedSeq
-        val tokenStrings = tokens.map { case (tokenSpan, _) => slab.spanned(tokenSpan)}
+        val tokens = tokenOps.selectTokens(slate, sentenceSpan).toIndexedSeq
+        val tokenStrings = tokens.map { case (tokenSpan, _) => slate.spanned(tokenSpan)}
 
         // Run ClearNLP pos tagger
         val clearNlpDepTree = new DEPTree(tokenStrings)
@@ -43,8 +43,8 @@ abstract class PosTaggerImplBase[SENTENCE, TOKEN, POSTAG](
 
     // Strangely this needs to be split into two lines or else
     // we get a compiler error
-    val resultSlab = posTagOps.addPosTags(slab, posTaggedTokenSpans)
-    resultSlab
+    val resultSlate = posTagOps.addPosTags(slate, posTaggedTokenSpans)
+    resultSlate
   }
 
 }

--- a/src/main/scala/org/sparkle/clearnlp/Tokenizer.scala
+++ b/src/main/scala/org/sparkle/clearnlp/Tokenizer.scala
@@ -8,10 +8,9 @@ import edu.emory.clir.clearnlp.util.lang.TLanguage
 import org.sparkle.slate.Span
 
 import org.sparkle.slate._
-import epic.slab.Sentence
 import org.apache.commons.io.IOUtils
 import org.sparkle.preprocess.{SparkleTokenizer, SparkleSentenceSegmenterAndTokenizer}
-import org.sparkle.typesystem.basic.Token
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 import scala.collection.mutable.ListBuffer
 import scala.collection.JavaConversions._

--- a/src/main/scala/org/sparkle/opennlp/SentDetect.scala
+++ b/src/main/scala/org/sparkle/opennlp/SentDetect.scala
@@ -1,11 +1,9 @@
 package org.sparkle.opennlp
 
-import java.io.InputStream
-
 import org.sparkle.slate._
-import epic.slab.Sentence
 import opennlp.tools.sentdetect.{SentenceDetectorME, SentenceModel}
-import org.sparkle.typesystem.ops.{EpicSentenceOps, SentenceOps}
+import org.sparkle.typesystem.ops.{SparkleSentenceOps, SentenceOps}
+import org.sparkle.typesystem.basic.Sentence
 
 import scala.collection.mutable.ListBuffer
 import scala.collection.JavaConversions._
@@ -74,7 +72,7 @@ abstract class OpenNlpSentenceSegmenterImplBase[SENTENCE_TYPE]( sentenceModelPat
 
 class OpenNlpSentenceSegmenter(sentenceModelPath: String)
   extends OpenNlpSentenceSegmenterImplBase[Sentence](sentenceModelPath) {
-  override val sentenceOps: SentenceOps[Sentence] = EpicSentenceOps
+  override val sentenceOps: SentenceOps[Sentence] = SparkleSentenceOps
 }
 
 object OpenNlpSentenceSegmenter {

--- a/src/main/scala/org/sparkle/opennlp/SentDetect.scala
+++ b/src/main/scala/org/sparkle/opennlp/SentDetect.scala
@@ -2,17 +2,16 @@ package org.sparkle.opennlp
 
 import java.io.InputStream
 
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Sentence
 import opennlp.tools.sentdetect.{SentenceDetectorME, SentenceModel}
-import org.sparkle.typesystem.basic.{Token}
 import org.sparkle.typesystem.ops.{EpicSentenceOps, SentenceOps}
 
 import scala.collection.mutable.ListBuffer
 import scala.collection.JavaConversions._
 
 abstract class OpenNlpSentenceSegmenterImplBase[SENTENCE_TYPE]( sentenceModelPath: String)
-  extends StringAnalysisFunction[Any, SENTENCE_TYPE] with Serializable {
+  extends StringAnalysisFunction with Serializable {
 
   val multipleNewlinesRegex = "(?m)\\s*\\n\\s*\\n\\s*".r
   val leadingWhitespaceRegex = "^\\s+".r
@@ -30,15 +29,15 @@ abstract class OpenNlpSentenceSegmenterImplBase[SENTENCE_TYPE]( sentenceModelPat
     (offsets1.toList ::: offsets2.toList).sortWith((x,y) => x < y)
   }
 
-  override def apply[In <: Any](slab: Slab[String, Span, In]): Slab[String, Span, In with SENTENCE_TYPE] = {
-    // Convert slab text to an input stream and run with ClearNLP
-    val sentenceOffsets = getSentenceOffsets(slab.content)
+  override def apply(slate: StringSlate): StringSlate = {
+    // Convert slate text to an input stream and run with ClearNLP
+    val sentenceOffsets = getSentenceOffsets(slate.content)
     val sentences = ListBuffer[Tuple2[Span, SENTENCE_TYPE]]()
 
     var begin = 0
     var end = 0
     val textOffset = 0
-    val text = slab.content
+    val text = slate.content
 
     // advance the first sentence to first non-whitespace char
     leadingWhitespaceRegex.findFirstMatchIn(text).foreach(m => begin += m.group(0).length)
@@ -67,7 +66,7 @@ abstract class OpenNlpSentenceSegmenterImplBase[SENTENCE_TYPE]( sentenceModelPat
 
     }
 
-    val updated = sentenceOps.addSentences(slab, sentences)
+    val updated = sentenceOps.addSentences(slate, sentences)
     updated
   }
 
@@ -84,7 +83,7 @@ object OpenNlpSentenceSegmenter {
 
 }
 
-object SentenceSegmenter extends epic.preprocess.SentenceSegmenter {
+object SentenceSegmenter extends org.sparkle.slate.analyzers.SentenceSegmenter {
   // FIXME parameterize language code and pre-load tokenizer
   val sentenceModelPath = "/opennlp/models/en-sent.bin"
   val multipleNewlinesRegex = "(?m)\\s*\\n\\s*\\n\\s*".r
@@ -103,16 +102,16 @@ object SentenceSegmenter extends epic.preprocess.SentenceSegmenter {
   }
 
 
-  override def apply[In](slab: StringSlab[In]): StringSlab[In with Sentence] = {
+  override def apply(slate: StringSlate): StringSlate = {
 
-    // Convert slab text to an input stream and run with ClearNLP
-    val sentenceOffsets = getSentenceOffsets(slab.content)
+    // Convert slate text to an input stream and run with ClearNLP
+    val sentenceOffsets = getSentenceOffsets(slate.content)
     val sentences = ListBuffer[Tuple2[Span, Sentence]]()
 
     var begin = 0
     var end = 0
     val textOffset = 0
-    val text = slab.content
+    val text = slate.content
 
     // advance the first sentence to first non-whitespace char
     leadingWhitespaceRegex.findFirstMatchIn(text).foreach(m => begin += m.group(0).length)
@@ -143,7 +142,7 @@ object SentenceSegmenter extends epic.preprocess.SentenceSegmenter {
 
 
 
-    slab.addLayer[Sentence](sentences)
+    slate.addLayer[Sentence](sentences)
   }
 }
 

--- a/src/main/scala/org/sparkle/preprocess/RegexSplitTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/RegexSplitTokenizer.scala
@@ -2,8 +2,7 @@ package org.sparkle.preprocess
 
 import java.util.regex.Pattern
 
-import epic.trees.Span
-import epic.slab._
+import org.sparkle.slate._
 import org.sparkle.typesystem.basic.Token
 
 import scala.collection.mutable.ArrayBuffer
@@ -19,7 +18,7 @@ case class RegexSplitTokenizer(pattern : String) extends SparkleTokenizer {
 
   private val regex = Pattern.compile(pattern)
 
-  def apply[In](slab: StringSlab[In]): StringSlab[In with Token] = {
+  def apply(slab: StringSlate): StringSlate = {
     val m = regex.matcher(slab.content)
 
     val spans = new ArrayBuffer[(Span, Token)]()

--- a/src/main/scala/org/sparkle/preprocess/RegexSplitTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/RegexSplitTokenizer.scala
@@ -18,8 +18,8 @@ case class RegexSplitTokenizer(pattern : String) extends SparkleTokenizer {
 
   private val regex = Pattern.compile(pattern)
 
-  def apply(slab: StringSlate): StringSlate = {
-    val m = regex.matcher(slab.content)
+  def apply(slate: StringSlate): StringSlate = {
+    val m = regex.matcher(slate.content)
 
     val spans = new ArrayBuffer[(Span, Token)]()
 
@@ -27,12 +27,12 @@ case class RegexSplitTokenizer(pattern : String) extends SparkleTokenizer {
     while (m.find()) {
       val end = m.start()
       if (end - start >= 1)
-        spans += (Span(start, end) -> Token(slab.content.substring(start, end)))
+        spans += (Span(start, end) -> Token(slate.content.substring(start, end)))
       start = m.end()
     }
-    if(start != slab.content.length)
-      spans += Span(start, slab.content.length) -> Token(slab.content.substring(start, slab.content.length))
-    slab.addLayer[Token](spans)
+    if(start != slate.content.length)
+      spans += Span(start, slate.content.length) -> Token(slate.content.substring(start, slate.content.length))
+    slate.addLayer[Token](spans)
   }
 
 }

--- a/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
@@ -11,7 +11,7 @@ trait SparkleSentenceSegmenterAndTokenizer extends StringAnalysisFunction with S
   override def toString = getClass.getName
 
   def apply(a: String):IndexedSeq[String] = {
-    val slab = Slate(a)
-    apply(slab).iterator[Sentence with Token].toIndexedSeq.map(s => slab.spanned(s._1))
+    val slate = Slate(a)
+    apply(slate).iterator[Sentence with Token].toIndexedSeq.map(s => slate.spanned(s._1))
   }
 }

--- a/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
@@ -1,7 +1,6 @@
 package org.sparkle.preprocess
 import org.sparkle.slate.{StringAnalysisFunction, Slate}
-import epic.slab.Sentence
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 /**
   * Created by leebecker on 2/4/16.

--- a/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleSentenceSegmenterAndTokenizer.scala
@@ -1,5 +1,6 @@
 package org.sparkle.preprocess
-import epic.slab.{StringAnalysisFunction, Sentence, Slab}
+import org.sparkle.slate.{StringAnalysisFunction, Slate}
+import epic.slab.Sentence
 import org.sparkle.typesystem.basic.{Token}
 
 /**
@@ -7,11 +8,11 @@ import org.sparkle.typesystem.basic.{Token}
   *
   *
   */
-trait SparkleSentenceSegmenterAndTokenizer extends StringAnalysisFunction[Any, Sentence with Token] with (String => Iterable[String]) with Serializable {
+trait SparkleSentenceSegmenterAndTokenizer extends StringAnalysisFunction with Serializable {
   override def toString = getClass.getName
 
   def apply(a: String):IndexedSeq[String] = {
-    val slab = Slab(a)
+    val slab = Slate(a)
     apply(slab).iterator[Sentence with Token].toIndexedSeq.map(s => slab.spanned(s._1))
   }
 }

--- a/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
@@ -16,8 +16,7 @@
 package org.sparkle.preprocess
 
 import org.sparkle.slate._
-import org.sparkle.typesystem.basic.{Token}
-import epic.slab.Sentence
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 
 /**

--- a/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
@@ -30,8 +30,8 @@ trait SparkleTokenizer extends StringAnalysisFunction with Serializable with (St
   override def toString() = getClass.getName +"()"
 
   def apply(a: String):IndexedSeq[String] = {
-    val slab = apply(Slate(a).append(Span(0, a.length), Sentence()))
-    slab.iterator[Token].map(_._2.token).toIndexedSeq
+    val slate = apply(Slate(a).append(Span(0, a.length), Sentence()))
+    slate.iterator[Token].map(_._2.token).toIndexedSeq
   }
 
 }

--- a/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
+++ b/src/main/scala/org/sparkle/preprocess/SparkleTokenizer.scala
@@ -15,23 +15,23 @@
 */
 package org.sparkle.preprocess
 
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
 import org.sparkle.typesystem.basic.{Token}
+import epic.slab.Sentence
 
 
 /**
  * Abstract trait for tokenizers, which annotate sentence-segmented text with tokens. Tokenizers work
- * with both raw strings and [[org.sparkle.slab.StringSlab]]s.
+ * with both raw strings and [[org.sparkle.slate.StringSlate]]s.
  *
  * @author dlwh
  */
 @SerialVersionUID(1)
-trait SparkleTokenizer extends StringAnalysisFunction[Sentence, Token] with Serializable with (String=>IndexedSeq[String]) {
+trait SparkleTokenizer extends StringAnalysisFunction with Serializable with (String=>IndexedSeq[String]) {
   override def toString() = getClass.getName +"()"
 
   def apply(a: String):IndexedSeq[String] = {
-    val slab = apply(Slab(a).append(Span(0, a.length), Sentence()))
+    val slab = apply(Slate(a).append(Span(0, a.length), Sentence()))
     slab.iterator[Token].map(_._2.token).toIndexedSeq
   }
 

--- a/src/main/scala/org/sparkle/slate/AnalysisFunction.scala
+++ b/src/main/scala/org/sparkle/slate/AnalysisFunction.scala
@@ -1,0 +1,46 @@
+package org.sparkle.slate
+
+//import epic.preprocess.{RegexSentenceSegmenter, Tokenizer}
+//import epic.trees.Span
+
+/**
+  * An analysis function that takes a Slate with declared annotation types in it and outputs
+  * a new Slate with additional annotations of a new type.
+  *
+  *   B = Base annotation type
+  *   I = Input annotation type
+  *   O = Output annotation type
+  */
+
+
+/**
+  * Documentation for the type variables:
+  *   C = Content type (e.g. String, Image)
+  *   R = Region Type
+  * @tparam C content type (e.g. String, Image)
+  * @tparam R region type (e.g. Span, Block, etc...)
+  */
+trait AnalysisFunction[C,R] {
+  def apply(slate: Slate[C,R]):Slate[C,R]
+
+  def andThen(other: AnalysisFunction[C, R]): AnalysisFunction[C, R] = {
+    new ComposedAnalysisFunction[C, R](this, other)
+  }
+
+}
+
+case class ComposedAnalysisFunction[C, R](a: AnalysisFunction[C,R], b: AnalysisFunction[C,R])
+  extends AnalysisFunction[C, R] {
+
+  def apply(slate: Slate[C,R]):Slate[C,R] = {
+    b(a(slate))
+  }
+
+}
+
+
+object StringIdentityAnalyzer extends StringAnalysisFunction {
+  def apply(slate: StringSlate):StringSlate = slate
+}
+
+

--- a/src/main/scala/org/sparkle/slate/Slate.scala
+++ b/src/main/scala/org/sparkle/slate/Slate.scala
@@ -46,7 +46,7 @@ trait Slate[ContentType, RegionType] {
     }
   }
 
-  /** Queries whether we have annotations of this type, even if the slab
+  /** Queries whether we have annotations of this type, even if the slate
     *  doesn't have this type. Sometimes you just have to cast... */
   def hasLayer[A :ClassTag]:Boolean
 
@@ -123,7 +123,7 @@ object Slate {
   }
 
   /**
-    * This slab should be more efficient, especially for longer documents. It maintains the annotations in sorted order.
+    * This slate should be more efficient, especially for longer documents. It maintains the annotations in sorted order.
     *
     * @param content
     * @param annotations
@@ -157,7 +157,7 @@ object Slate {
     }
 
 
-    /** Queries whether we have annotations of this type, even if the slab
+    /** Queries whether we have annotations of this type, even if the slate
       * doesn't have this type. Sometimes you just have to cast... */
     override def hasLayer[A: ClassTag]: Boolean = {
       annotations.contains(implicitly[ClassTag[A]].runtimeClass)

--- a/src/main/scala/org/sparkle/slate/Slate.scala
+++ b/src/main/scala/org/sparkle/slate/Slate.scala
@@ -1,0 +1,220 @@
+package org.sparkle.slate
+
+import epic.util.BinarySearch
+
+import scala.reflect.ClassTag
+import org.sparkle.slate.AnnotatedSpan.{EndFirstSpanOrdering, SpanOrdering}
+
+//trait AnnotationTypes
+
+
+/**
+  * Blatently stolen from Epic's Slabs, but simpler as they don't track AnnotationTypes.  Annotation Types will
+  * Simply inherit from Annotation
+  * Immutable and lovely
+  */
+trait Slate[ContentType, RegionType] {
+
+  val content: ContentType
+
+  def spanned(region: RegionType): ContentType
+
+  // Add a new annotation to the slate
+  def append[A:ClassTag](region: RegionType, annotation: A): Slate[ContentType, RegionType] = {
+    this.+[A](region -> annotation)
+  }
+
+  // Add a new annotation to the slate
+  def +[A:ClassTag](pair: (RegionType, A)): Slate[ContentType, RegionType] = {
+    addLayer[A](pair)
+  }
+
+  def addLayer[A:ClassTag](annotations: TraversableOnce[(RegionType, A)]): Slate[ContentType, RegionType]
+
+  def addLayer[A:ClassTag](annotations: (RegionType, A)*): Slate[ContentType, RegionType] = {
+    addLayer[A](annotations)
+  }
+
+  /** Can't remove the type, but you can upcast */
+  def removeLayer[A: ClassTag]: Slate[ContentType, RegionType]
+
+  /** useful for downcasting */
+  def checkedCast[A: ClassTag]:Option[Slate[ContentType, RegionType]] = {
+    if(!hasLayer[A]) {
+      None
+    } else {
+      Some(this.asInstanceOf[Slate[ContentType, RegionType]])
+    }
+  }
+
+  /** Queries whether we have annotations of this type, even if the slab
+    *  doesn't have this type. Sometimes you just have to cast... */
+  def hasLayer[A :ClassTag]:Boolean
+
+  //def iterator[A >: AnnotationTypes: ClassTag](aType: ClassTag[A]): Iterator[(RegionType, A)]
+  def iterator[A : ClassTag](aType: ClassTag[A]): Iterator[(RegionType, A)]
+
+  //def indexedSeq[A >: AnnotationTypes : ClassTag](aType: ClassTag[A]): IndexedSeq[(RegionType, A)]
+  def indexedSeq[A : ClassTag](aType: ClassTag[A]): IndexedSeq[(RegionType, A)]
+
+  /**
+    * Returns annotations wholly contained in the region
+ *
+    * @param region
+    * @tparam A
+    * @return
+    */
+  //def covered[A >: AnnotationTypes: ClassTag](region: RegionType, aType: ClassTag[A]): IndexedSeq[(RegionType, A)]
+  def covered[A : ClassTag](region: RegionType, aType: ClassTag[A]): IndexedSeq[(RegionType, A)]
+
+
+  /**
+   * Returns annotations that are entirely before the region
+ *
+   * @param region
+    * @param aType annotation type
+   * @tparam A
+   * @return
+  */
+  //def preceding[A >: AnnotationTypes: ClassTag](region: RegionType, aType: ClassTag[A]): Iterator[(RegionType, A)]
+  def preceding[A : ClassTag](region: RegionType, aType: ClassTag[A]): Iterator[(RegionType, A)]
+
+  //def following[A >: AnnotationTypes: ClassTag](region: RegionType, aType: ClassTag[A]): Iterator[(RegionType, A)]
+  def following[A : ClassTag](region: RegionType, aType: ClassTag[A]): Iterator[(RegionType, A)]
+
+  /*
+  def stringRep[A >: AnnotationTypes: ClassTag](annotationType: ClassTag[A]) = {
+    iterator[A].mkString("\n")
+  }
+  */
+
+}
+
+object AnnotatedSpan {
+
+  implicit object SpanOrdering extends Ordering[Span] {
+    override def compare(x: Span, y: Span): Int = {
+      if      (x.begin < y.begin) -1
+      else if (x.begin > y.begin)  1
+      else if (x.end  < y.end)    -1
+      else if (x.end > y.end)      1
+      else                         0
+    }
+  }
+
+  implicit object EndFirstSpanOrdering extends Ordering[Span] {
+    override def compare(x: Span, y: Span): Int = {
+      if (x.end  < y.end)    -1
+      else if (x.end > y.end)      1
+      else if (x.begin < y.begin) -1
+      else if (x.begin > y.begin)  1
+      else                         0
+    }
+  }
+
+}
+
+
+object Slate {
+
+  trait ExtractRegion[Region, T] {
+    def apply(region: Region, t: T):T
+  }
+
+  implicit object SpanStringExtractRegion extends ExtractRegion[Span, String] {
+    def apply(region: Span, t: String) = t.substring(region.begin, region.end)
+  }
+
+  def apply(content: String):StringSlate = {
+    new SortedSequenceSlate(content, Map.empty, Map.empty)
+  }
+
+  /**
+    * This slab should be more efficient, especially for longer documents. It maintains the annotations in sorted order.
+    *
+    * @param content
+    * @param annotations
+    * @tparam ContentType
+    */
+  private[slate] class SortedSequenceSlate[ContentType]
+   (val content: ContentType,
+    val annotations: Map[Class[_], Vector[(Span, Any)]] = Map.empty,
+    val reverseAnnotations: Map[Class[_], Vector[(Span, Any)]] = Map.empty)(implicit extract: ExtractRegion[Span, ContentType]) extends Slate[ContentType, Span] {
+
+    override def spanned(region: Span): ContentType = extract(region, content)
+
+    override def addLayer[A:ClassTag](annotations: TraversableOnce[(Span, A)]): Slate[ContentType, Span] = {
+      val ann = annotations.toSeq
+      var newAnnotations = this.annotations
+      val clss = implicitly[ClassTag[A]].runtimeClass
+      newAnnotations = newAnnotations + (clss -> (newAnnotations.getOrElse(clss, Vector.empty) ++ ann).sortBy(_._1)(SpanOrdering))
+
+      val reverseAnnotations = {
+        this.reverseAnnotations + (clss -> (this.reverseAnnotations.getOrElse(clss, Vector.empty) ++ ann).sortBy(_._1)(EndFirstSpanOrdering))
+      }
+
+      new SortedSequenceSlate(content, newAnnotations, reverseAnnotations)
+    }
+
+
+    override def removeLayer[A :  ClassTag]: Slate[ContentType, Span] = {
+      new SortedSequenceSlate(content,
+        annotations - implicitly[ClassTag[A]].runtimeClass,
+        reverseAnnotations - implicitly[ClassTag[A]].runtimeClass)
+    }
+
+
+    /** Queries whether we have annotations of this type, even if the slab
+      * doesn't have this type. Sometimes you just have to cast... */
+    override def hasLayer[A: ClassTag]: Boolean = {
+      annotations.contains(implicitly[ClassTag[A]].runtimeClass)
+    }
+
+    override def following[A : ClassTag](region: Span, aType: ClassTag[A]): Iterator[(Span, A)] = {
+      val annotations = selectAnnotations[A](aType)
+      var pos = BinarySearch.interpolationSearch(annotations, (_:(Span, Any))._1.begin, region.end)
+      if(pos < 0) pos = ~pos
+      annotations.view(pos, annotations.length).iterator
+    }
+
+    override def preceding[A : ClassTag](region: Span, aType: ClassTag[A]): Iterator[(Span, A)] = {
+      val annotations = selectReverse[A]
+      var pos = BinarySearch.interpolationSearch(annotations, (_:(Span, Any))._1.end, region.begin + 1)
+      if(pos < 0) pos = ~pos
+      annotations.view(0, pos).reverseIterator
+    }
+
+    override def covered[A  : ClassTag](region: Span, aType: ClassTag[A]): IndexedSeq[(Span, A)] = {
+      val annotations = selectAnnotations[A](aType)
+      var begin = BinarySearch.interpolationSearch(annotations, (_:(Span, Any))._1.begin, region.begin)
+      if(begin < 0) begin = ~begin
+      var end = annotations.indexWhere(_._1.end > region.end, begin)
+      if(end < 0) end = annotations.length
+      annotations.slice(begin, end)
+    }
+
+    override def iterator[A : ClassTag](aType: ClassTag[A]): Iterator[(Span, A)] = {
+      selectAnnotations[A](aType).iterator
+    }
+
+    override def indexedSeq[A : ClassTag](aType: ClassTag[A]): IndexedSeq[(Span, A)] = {
+      selectAnnotations(aType)
+    }
+
+    private def selectAnnotations[A : ClassTag](aType: ClassTag[A]): IndexedSeq[(Span, A)] = {
+      annotations.getOrElse(implicitly[ClassTag[A]].runtimeClass, IndexedSeq.empty).asInstanceOf[IndexedSeq[(Span, A)]]
+    }
+
+    private def selectReverse[A : ClassTag]:  IndexedSeq[(Span, A)] = {
+      reverseAnnotations.getOrElse(implicitly[ClassTag[A]].runtimeClass, IndexedSeq.empty).asInstanceOf[IndexedSeq[(Span, A)]]
+    }
+
+    /*
+    override def stringRep[A >: AnnotationType: ClassTag] = {
+      iterator[A].map { case (Span(begin, end), x) => s"Span($begin, $end) $x"}.mkString("\n")
+    }
+    */
+
+  }
+
+}

--- a/src/main/scala/org/sparkle/slate/SlateTest.sc
+++ b/src/main/scala/org/sparkle/slate/SlateTest.sc
@@ -1,0 +1,93 @@
+import epic.slab.Sentence
+import org.sparkle.slate.{Slate, Span, StringAnalysisFunction, StringSlate}
+import org.sparkle.typesystem.basic.Token
+
+import scala.reflect._
+
+
+val slate = Slate("This is ok. That is better.")
+println(slate.content)
+
+
+/*
+object DumbSentencer extends StringAnalysisFunction {
+
+  def apply(slate: StringSlate) = {
+    val sentenceSpans = Seq(Span(0,10), Span(12, 25))
+    val sentences = Seq(Sentence(), Sentence())
+    slate.addLayer(sentenceSpans.zip(sentences))
+  }
+}
+*/
+
+trait SentenceSegmenter extends StringAnalysisFunction with (String => Iterable[String]) with Serializable {
+  override def toString = getClass.getName
+
+  def apply(a: String):IndexedSeq[String] = {
+    val slate = Slate(a)
+    apply(slate).iterator(classTag[Sentence]).toIndexedSeq.map(s => slate.spanned(s._1))
+  }
+
+}
+
+object RegexSentenceSegmenter extends SentenceSegmenter {
+
+  def apply(slate: StringSlate) =
+  // the [Sentence] is required because of https://issues.scala-lang.org/browse/SI-7647
+    slate.addLayer[Sentence]("[^\\s.!?]+([^.!?]+[.!?]|\\z)".r.findAllMatchIn(slate.content).map(m => Span(m.start, m.end) -> Sentence()))
+}
+
+@SerialVersionUID(1)
+trait Tokenizer extends StringAnalysisFunction with Serializable with (String=>IndexedSeq[String]) {
+  override def toString() = getClass.getName +"()"
+
+  def apply(a: String):IndexedSeq[String] = {
+    val slab = apply(Slate(a).append(Span(0, a.length), Sentence()))
+    slab.iterator(classTag[Token]).map(_._2.token).toIndexedSeq
+  }
+
+}
+
+object RegexTokenizer extends Tokenizer {
+  def apply(slab: StringSlate) =
+  // the [Token] is required because of https://issues.scala-lang.org/browse/SI-7647
+    slab.addLayer(slab.iterator(classTag[Sentence]).flatMap{ case (region, sentence) =>
+      "\\p{L}+|\\p{P}+|\\p{N}+".r.findAllMatchIn(slab.content.substring(region.begin, region.end)).map(m =>
+        Span(region.begin + m.start, region.begin + m.end) -> Token(m.group(0)))
+    })
+}
+
+val pipeline = RegexSentenceSegmenter andThen RegexTokenizer
+val analysis =  pipeline(slate)
+val x = classTag[Token]
+println(analysis.iterator(x).toList);
+
+
+def covering[PARENT:ClassTag,CHILD:ClassTag](slate: StringSlate, parentType: ClassTag[PARENT], childType: ClassTag[CHILD]) = {
+  slate.iterator[PARENT](parentType).map{ case (span, parent) =>
+      slate.covered[CHILD](span, childType).toList
+  }
+}
+
+print ("HEREREHERRE")
+covering(analysis, classTag[Sentence], classTag[Token])
+
+val tokenClass = "org.sparkle.typesystem.basic.Token"
+//println(analysis.iterator(tokenClass).toList);
+
+
+/*
+import scala.reflect.runtime.universe
+import scala.reflect.runtime.universe._
+import scala.reflect.ManifestFactory
+
+val className = "java.lang.String"
+val mirror = universe.runtimeMirror(getClass.getClassLoader)
+
+val cls = Class.forName(tokenClass)
+val cls2= ClassTag[Token](cls)
+classTag[Token]
+analysis.iterator(ClassTag[Token](cls)).toList
+typeOf[Token]
+typeTag[Token]
+*/

--- a/src/main/scala/org/sparkle/slate/SlateTest.sc
+++ b/src/main/scala/org/sparkle/slate/SlateTest.sc
@@ -31,17 +31,17 @@ trait Tokenizer extends StringAnalysisFunction with Serializable with (String=>I
 
   def apply(a: String):IndexedSeq[String] = {
     val x = Slate(a).append(Span(0, a.length), Sentence())
-    val slab = apply(Slate(a).append(Span(0, a.length), Sentence()))
-    slab.iterator(classTag[Token]).map(_._2.token).toIndexedSeq
+    val slate = apply(Slate(a).append(Span(0, a.length), Sentence()))
+    slate.iterator(classTag[Token]).map(_._2.token).toIndexedSeq
   }
 
 }
 
 object RegexTokenizer extends Tokenizer {
-  def apply(slab: StringSlate) =
+  def apply(slate: StringSlate) =
   // the [Token] is required because of https://issues.scala-lang.org/browse/SI-7647
-    slab.addLayer(slab.iterator(classTag[Sentence]).flatMap{ case (region, sentence) =>
-      "\\p{L}+|\\p{P}+|\\p{N}+".r.findAllMatchIn(slab.content.substring(region.begin, region.end)).map(m =>
+    slate.addLayer(slate.iterator(classTag[Sentence]).flatMap{ case (region, sentence) =>
+      "\\p{L}+|\\p{P}+|\\p{N}+".r.findAllMatchIn(slate.content.substring(region.begin, region.end)).map(m =>
         Span(region.begin + m.start, region.begin + m.end) -> Token(m.group(0)))
     })
 }

--- a/src/main/scala/org/sparkle/slate/Span.scala
+++ b/src/main/scala/org/sparkle/slate/Span.scala
@@ -1,0 +1,79 @@
+package org.sparkle.slate
+
+import spire.syntax.cfor
+
+/*
+ Copyright 2012 David Hall
+ Licensed under the Apache License, Version 2.0 (the "License")
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+
+class Span(val encoded: Long) extends AnyVal with Serializable {
+  def toPair: (Int, Int) = (begin, end)
+
+  def begin = (encoded >>> 32).toInt
+  def end = encoded.toInt
+
+  def isEmpty = begin == end
+  def nonEmpty = !isEmpty
+
+  def length = end - begin
+
+  def map[U](f: Int=>U) = Range(begin,end).map(f)
+
+  @inline
+  def foreach(f: Int=>Unit) = {
+    cfor.cfor(begin)(_ < end, _ +1) { f }
+  }
+
+  def iterator = toRange.iterator
+
+  def toRange = Range(begin,end)
+
+  def contains(pos: Int) = pos >= begin && pos < end
+
+  /**
+    * Returns true if this and other overlap but containment or equality does not hold.
+    * @param other
+    * @return
+    */
+  def crosses(other: Span) = (
+    (begin < other.begin && end < other.end && end > other.begin)
+      ||  (other.begin < begin && other.end < end && other.end > begin)
+    )
+
+
+  //  override def hashCode(): Int = {
+  //    (begin, end).hashCode()
+  //  }
+  //
+  //  override def equals(obj: scala.Any): Boolean = this match {
+  //    case other: Span => this.begin == other.begin && this.end == other.end
+  //    case _ => false
+  //  }
+
+  /**
+    * Return true if this' range contains the other range.
+    */
+  def contains(other:Span) = {
+    begin <= other.begin && end >= other.end
+  }
+
+  def toIndexedSeq = Range(begin, end)
+
+  override def toString = s"Span($begin, $end)"
+}
+
+object Span {
+  def apply(begin: Int, end: Int) = new Span((begin.toLong << 32) | (end.toLong&0xFFFFFFFFL))
+
+  def unapply(span: Span) = Some((span.begin, span.end))
+}

--- a/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
+++ b/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
@@ -4,7 +4,8 @@ import java.io.FileInputStream
 
 import breeze.config.CommandLineParser
 import org.sparkle.slate._
-import epic.slab.Sentence
+import org.sparkle.typesystem.basic.Sentence
+
 import scala.reflect._
 
 /**

--- a/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
+++ b/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
@@ -16,8 +16,8 @@ trait SentenceSegmenter extends StringAnalysisFunction with Serializable {
   override def toString = getClass.getName
 
   def apply(a: String):IndexedSeq[String] = {
-    val slab = Slate(a)
-    apply(slab).iterator(classTag[Sentence]).toIndexedSeq.map(s => slab.spanned(s._1))
+    val slate = Slate(a)
+    apply(slate).iterator(classTag[Sentence]).toIndexedSeq.map(s => slate.spanned(s._1))
   }
 
 }

--- a/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
+++ b/src/main/scala/org/sparkle/slate/analyzers/SentenceSegmenter.scala
@@ -1,0 +1,46 @@
+package org.sparkle.slate.analyzers
+
+import java.io.FileInputStream
+
+import breeze.config.CommandLineParser
+import org.sparkle.slate._
+import epic.slab.Sentence
+import scala.reflect._
+
+/**
+  *
+  * @author dlwh
+  */
+trait SentenceSegmenter extends StringAnalysisFunction with Serializable {
+  override def toString = getClass.getName
+
+  def apply(a: String):IndexedSeq[String] = {
+    val slab = Slate(a)
+    apply(slab).iterator(classTag[Sentence]).toIndexedSeq.map(s => slab.spanned(s._1))
+  }
+
+}
+
+
+/*
+object SegmentSentences {
+  case class Params(splitOnNewline: Boolean = false)
+  def main(_args: Array[String]):Unit = {
+    val (config, args) = CommandLineParser.parseArguments(_args)
+    val params = config.readIn[Params]()
+    import params._
+
+    val ins = if(args.isEmpty) IndexedSeq(System.in) else args.toStream.map(new FileInputStream(_))
+    val streaming = new StreamSentenceSegmenter(MLSentenceSegmenter.bundled().get, segmentOnNewLines = params.splitOnNewline)
+    for(in <- ins) {
+      try {
+        for(s <- streaming.sentences(in)) {
+          println(s.replaceAll("\n"," ").trim)
+        }
+      } finally {
+        in.close()
+      }
+    }
+  }
+}
+*/

--- a/src/main/scala/org/sparkle/slate/package.scala
+++ b/src/main/scala/org/sparkle/slate/package.scala
@@ -1,0 +1,9 @@
+package org.sparkle
+
+/**
+  * Created by leebecker on 4/14/16.
+  */
+package object slate {
+  type StringAnalysisFunction = AnalysisFunction[String, Span]
+  type StringSlate = Slate[String, Span]
+}

--- a/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
+++ b/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
@@ -1,4 +1,4 @@
-package org.sparkle
+package org.sparkle.slate.spark
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.Transformer
@@ -6,10 +6,12 @@ import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.ScalaReflection
-import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row}
+import org.sparkle.StringSlateExtractor
 import org.sparkle.slate._
+
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 

--- a/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
+++ b/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
@@ -9,14 +9,13 @@ import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
-import org.sparkle.StringSlateExtractor
 import org.sparkle.slate._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
 
-class SparkleSlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) extends Transformer {
+class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) extends Transformer {
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor"))
 
   val slatePipelineFunc: Param[(StringSlate)=>(StringSlate)] = new Param(this, "slatePipelineFunc",
@@ -26,8 +25,6 @@ class SparkleSlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: St
   def getSlatePipelineFunc: (StringSlate)=>(StringSlate) = $(slatePipelineFunc)
 
   def setSlatePipelineFunc(value: (StringSlate)=>(StringSlate)): this.type = set(slatePipelineFunc, value)
-
-  //@transient var pipeline: StringAnalysisFunction = _
 
   val textCol: Param[String] = new Param(this, "textCol", "name of column containing text to be analyzed")
 
@@ -90,8 +87,8 @@ class SparkleSlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: St
   override def transformSchema(schemaIn: StructType): StructType = StructType(schemaIn ++ getExtractorSchemas)
 }
 
-class SparkleSlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](override val uid: String)
-  extends SparkleSlateExtractorTransformer[T1] {
+class SlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](override val uid: String)
+  extends SlateExtractorTransformer[T1] {
 
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor2"))
 
@@ -114,8 +111,8 @@ class SparkleSlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag
   }
 }
 
- class SparkleSlateExtractorTransformer3[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag, T3:TypeTag:ClassTag](override val uid: String)
-  extends SparkleSlateExtractorTransformer2[T1,T2] {
+ class SlateExtractorTransformer3[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag, T3:TypeTag:ClassTag](override val uid: String)
+  extends SlateExtractorTransformer2[T1,T2] {
 
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor3"))
 
@@ -139,10 +136,11 @@ class SparkleSlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag
 }
 
 
-
-
-object SparkleSlateExtractorTransformer {
-  def create[T1:TypeTag:ClassTag] = new SparkleSlateExtractorTransformer[T1]()
-  def create[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag] = new SparkleSlateExtractorTransformer2[T1, T2]()
-  def create[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag, T3:TypeTag:ClassTag] = new SparkleSlateExtractorTransformer3[T1, T2, T3]()
+/**
+  * Convenience factories for SlateExtractorTransformer
+  */
+object SlateExtractorTransformer {
+  def apply[T1:TypeTag:ClassTag] = new SlateExtractorTransformer[T1]()
+  def apply[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag] = new SlateExtractorTransformer2[T1, T2]()
+  def apply[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag, T3:TypeTag:ClassTag] = new SlateExtractorTransformer3[T1, T2, T3]()
 }

--- a/src/main/scala/org/sparkle/slate/spark/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/slate/spark/StringSlateExtractor.scala
@@ -1,7 +1,7 @@
-package org.sparkle
+package org.sparkle.slate.spark
 
 import epic.slab.Sentence
-import org.sparkle.slate.{Span, StringSlate}
+import org.sparkle.slate.StringSlate
 import org.sparkle.typesystem.basic.Token
 
 

--- a/src/main/scala/org/sparkle/slate/spark/StringSlateExtractor.scala
+++ b/src/main/scala/org/sparkle/slate/spark/StringSlateExtractor.scala
@@ -1,8 +1,7 @@
 package org.sparkle.slate.spark
 
-import epic.slab.Sentence
 import org.sparkle.slate.StringSlate
-import org.sparkle.typesystem.basic.Token
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 
 

--- a/src/main/scala/org/sparkle/typesystem/basic/Sentence.scala
+++ b/src/main/scala/org/sparkle/typesystem/basic/Sentence.scala
@@ -1,0 +1,6 @@
+package org.sparkle.typesystem.basic
+
+/**
+  * Created by leebecker on 4/18/16.
+  */
+case class Sentence(id: Option[String] = None)

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicPartOfSpeechOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicPartOfSpeechOps.scala
@@ -7,13 +7,13 @@ import org.sparkle.slate._
   * Created by leebecker on 2/5/16.
   */
 object EpicPartOfSpeechOps extends PartOfSpeechOps[Token, PartOfSpeech]{
-  override def getPosTag[In <: PartOfSpeech](slab: StringSlate, span: Span, partOfSpeech: PartOfSpeech): Option[String] = {
+  override def getPosTag[In <: PartOfSpeech](slate: StringSlate, span: Span, partOfSpeech: PartOfSpeech): Option[String] = {
     val res = if (partOfSpeech.tag == null) None else Option(partOfSpeech.tag)
     res
   }
 
-  override def addPosTags[In <: Token](slab: StringSlate, posTags: TraversableOnce[(Span, PartOfSpeech)]):
-      StringSlate = slab.addLayer[PartOfSpeech](posTags)
+  override def addPosTags[In <: Token](slate: StringSlate, posTags: TraversableOnce[(Span, PartOfSpeech)]):
+      StringSlate = slate.addLayer[PartOfSpeech](posTags)
 
   override def createPosTag(tag: String, token: Token): PartOfSpeech = PartOfSpeech(tag)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicPartOfSpeechOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicPartOfSpeechOps.scala
@@ -1,19 +1,19 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.{PartOfSpeech, Token, StringSlab}
-import epic.trees.Span
+import epic.slab.{PartOfSpeech, Token}
+import org.sparkle.slate._
 
 /**
   * Created by leebecker on 2/5/16.
   */
 object EpicPartOfSpeechOps extends PartOfSpeechOps[Token, PartOfSpeech]{
-  override def getPosTag[In <: PartOfSpeech](slab: StringSlab[In], span: Span, partOfSpeech: PartOfSpeech): Option[String] = {
+  override def getPosTag[In <: PartOfSpeech](slab: StringSlate, span: Span, partOfSpeech: PartOfSpeech): Option[String] = {
     val res = if (partOfSpeech.tag == null) None else Option(partOfSpeech.tag)
     res
   }
 
-  override def addPosTags[In <: Token](slab: StringSlab[In], posTags: TraversableOnce[(Span, PartOfSpeech)]):
-      StringSlab[In with PartOfSpeech] = slab.addLayer[PartOfSpeech](posTags)
+  override def addPosTags[In <: Token](slab: StringSlate, posTags: TraversableOnce[(Span, PartOfSpeech)]):
+      StringSlate = slab.addLayer[PartOfSpeech](posTags)
 
   override def createPosTag(tag: String, token: Token): PartOfSpeech = PartOfSpeech(tag)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicSentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicSentenceOps.scala
@@ -1,7 +1,7 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.{Sentence, StringSlab}
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Sentence
 
 /**
   * Created by leebecker on 2/5/16.
@@ -9,12 +9,12 @@ import epic.trees.Span
 object EpicSentenceOps extends SentenceOps[epic.slab.Sentence] {
   override def createSentence(): Sentence = Sentence()
 
-  override def selectAllSentences[In <: Sentence](slab: StringSlab[In]): TraversableOnce[(Span, Sentence)] =
+  override def selectAllSentences[In <: Sentence](slab: StringSlate): TraversableOnce[(Span, Sentence)] =
     slab.iterator[Sentence]
 
-  override def selectSentences[In <: Sentence](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
+  override def selectSentences[In <: Sentence](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
     slab.covered[Sentence](coveringSpan)
 
-  override def addSentences[In](slab: StringSlab[In], sentences: TraversableOnce[(Span, Sentence)]):
-      StringSlab[In with Sentence] = slab.addLayer[Sentence](sentences)
+  override def addSentences(slab: StringSlate, sentences: TraversableOnce[(Span, Sentence)]):
+      StringSlate = slab.addLayer[Sentence](sentences)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicSentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicSentenceOps.scala
@@ -9,12 +9,12 @@ import epic.slab.Sentence
 object EpicSentenceOps extends SentenceOps[epic.slab.Sentence] {
   override def createSentence(): Sentence = Sentence()
 
-  override def selectAllSentences[In <: Sentence](slab: StringSlate): TraversableOnce[(Span, Sentence)] =
-    slab.iterator[Sentence]
+  override def selectAllSentences[In <: Sentence](slate: StringSlate): TraversableOnce[(Span, Sentence)] =
+    slate.iterator[Sentence]
 
-  override def selectSentences[In <: Sentence](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
-    slab.covered[Sentence](coveringSpan)
+  override def selectSentences[In <: Sentence](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
+    slate.covered[Sentence](coveringSpan)
 
-  override def addSentences(slab: StringSlate, sentences: TraversableOnce[(Span, Sentence)]):
-      StringSlate = slab.addLayer[Sentence](sentences)
+  override def addSentences(slate: StringSlate, sentences: TraversableOnce[(Span, Sentence)]):
+      StringSlate = slate.addLayer[Sentence](sentences)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicTokenOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicTokenOps.scala
@@ -9,11 +9,11 @@ import epic.slab.Token
 object EpicTokenOps extends TokenOps[Token]{
   override def create(text: String): Token = Token(text)
 
-  override def selectAllTokens[In <: Token](slab: StringSlate): TraversableOnce[(Span, Token)] = slab.iterator[Token]
+  override def selectAllTokens[In <: Token](slate: StringSlate): TraversableOnce[(Span, Token)] = slate.iterator[Token]
 
-  override def selectTokens[In <: Token](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Token)] =
-    slab.covered[Token](coveringSpan)
+  override def selectTokens[In <: Token](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Token)] =
+    slate.covered[Token](coveringSpan)
 
-  override def addTokens(slab: StringSlate, tokens: TraversableOnce[(Span, Token)]):
-      StringSlate = slab.addLayer[Token](tokens)
+  override def addTokens(slate: StringSlate, tokens: TraversableOnce[(Span, Token)]):
+      StringSlate = slate.addLayer[Token](tokens)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/EpicTokenOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/EpicTokenOps.scala
@@ -1,7 +1,7 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.{StringSlab, Token}
-import epic.trees.Span
+import org.sparkle.slate._
+import epic.slab.Token
 
 /**
   * Created by leebecker on 2/5/16.
@@ -9,11 +9,11 @@ import epic.trees.Span
 object EpicTokenOps extends TokenOps[Token]{
   override def create(text: String): Token = Token(text)
 
-  override def selectAllTokens[In <: Token](slab: StringSlab[In]): TraversableOnce[(Span, Token)] = slab.iterator[Token]
+  override def selectAllTokens[In <: Token](slab: StringSlate): TraversableOnce[(Span, Token)] = slab.iterator[Token]
 
-  override def selectTokens[In <: Token](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, Token)] =
+  override def selectTokens[In <: Token](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Token)] =
     slab.covered[Token](coveringSpan)
 
-  override def addTokens[In](slab: StringSlab[In], tokens: TraversableOnce[(Span, Token)]):
-      StringSlab[In with Token] = slab.addLayer[Token](tokens)
+  override def addTokens(slab: StringSlate, tokens: TraversableOnce[(Span, Token)]):
+      StringSlate = slab.addLayer[Token](tokens)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/PartOfSpeechOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/PartOfSpeechOps.scala
@@ -1,17 +1,15 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.StringSlab
-import epic.trees.Span
-import org.sparkle.typesystem.basic.Token
+import org.sparkle.slate._
 
 /**
   * Created by leebecker on 2/5/16.
   */
 trait PartOfSpeechOps[TOKEN_TYPE, POS_TYPE] {
 
-  def getPosTag[In <: POS_TYPE](slab: StringSlab[In], span: Span, partOfSpeech:POS_TYPE): Option[String]
+  def getPosTag[In <: POS_TYPE](slate: StringSlate, span: Span, partOfSpeech:POS_TYPE): Option[String]
 
   def createPosTag(tag: String, token: TOKEN_TYPE): POS_TYPE
 
-  def addPosTags[In <: TOKEN_TYPE](slab: StringSlab[In], posTags: TraversableOnce[(Span, POS_TYPE)]) : StringSlab[In with POS_TYPE]
+  def addPosTags[In <: TOKEN_TYPE](slate: StringSlate, posTags: TraversableOnce[(Span, POS_TYPE)]) : StringSlate
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SentenceOps.scala
@@ -1,7 +1,6 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.StringSlab
-import epic.trees.Span
+import org.sparkle.slate._
 
 /**
   * Created by leebecker on 2/5/16.
@@ -10,10 +9,9 @@ import epic.trees.Span
 trait SentenceOps[SENTENCE_TYPE] {
   def createSentence(): SENTENCE_TYPE
 
-  def selectSentences[In <: SENTENCE_TYPE](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, SENTENCE_TYPE)]
+  def selectSentences[In <: SENTENCE_TYPE](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, SENTENCE_TYPE)]
 
-  def selectAllSentences[In <: SENTENCE_TYPE](slab: StringSlab[In]): TraversableOnce[(Span, SENTENCE_TYPE)]
+  def selectAllSentences[In <: SENTENCE_TYPE](slab: StringSlate): TraversableOnce[(Span, SENTENCE_TYPE)]
 
-  def addSentences[In](slab: StringSlab[In], sentences: TraversableOnce[(Span, SENTENCE_TYPE)]):
-      StringSlab[In with SENTENCE_TYPE]
+  def addSentences(slate: StringSlate, sentences: TraversableOnce[(Span, SENTENCE_TYPE)]): StringSlate
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SentenceOps.scala
@@ -9,9 +9,9 @@ import org.sparkle.slate._
 trait SentenceOps[SENTENCE_TYPE] {
   def createSentence(): SENTENCE_TYPE
 
-  def selectSentences[In <: SENTENCE_TYPE](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, SENTENCE_TYPE)]
+  def selectSentences[In <: SENTENCE_TYPE](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, SENTENCE_TYPE)]
 
-  def selectAllSentences[In <: SENTENCE_TYPE](slab: StringSlate): TraversableOnce[(Span, SENTENCE_TYPE)]
+  def selectAllSentences[In <: SENTENCE_TYPE](slate: StringSlate): TraversableOnce[(Span, SENTENCE_TYPE)]
 
   def addSentences(slate: StringSlate, sentences: TraversableOnce[(Span, SENTENCE_TYPE)]): StringSlate
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SparklePartOfSpeechOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparklePartOfSpeechOps.scala
@@ -7,10 +7,10 @@ import org.sparkle.typesystem.basic.Token
   * Created by leebecker on 2/5/16.
   */
 object SparklePartOfSpeechOps extends PartOfSpeechOps[Token, Token]{
-  override def getPosTag[In <: Token](slab: StringSlate, span: Span, partOfSpeech: Token): Option[String] = partOfSpeech.pos
+  override def getPosTag[In <: Token](slate: StringSlate, span: Span, partOfSpeech: Token): Option[String] = partOfSpeech.pos
 
-  override def addPosTags[In <: Token](slab: StringSlate, posTags: TraversableOnce[(Span, Token)]): StringSlate =
-    slab.removeLayer[Token].addLayer[Token](posTags)
+  override def addPosTags[In <: Token](slate: StringSlate, posTags: TraversableOnce[(Span, Token)]): StringSlate =
+    slate.removeLayer[Token].addLayer[Token](posTags)
 
   override def createPosTag(tag: String, token: Token): Token = token.copy(pos=Option(tag))
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SparklePartOfSpeechOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparklePartOfSpeechOps.scala
@@ -1,17 +1,16 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.StringSlab
-import epic.trees.Span
+import org.sparkle.slate._
 import org.sparkle.typesystem.basic.Token
 
 /**
   * Created by leebecker on 2/5/16.
   */
 object SparklePartOfSpeechOps extends PartOfSpeechOps[Token, Token]{
-  override def getPosTag[In <: Token](slab: StringSlab[In], span: Span, partOfSpeech: Token): Option[String] = partOfSpeech.pos
+  override def getPosTag[In <: Token](slab: StringSlate, span: Span, partOfSpeech: Token): Option[String] = partOfSpeech.pos
 
-  override def addPosTags[In <: Token](slab: StringSlab[In], posTags: TraversableOnce[(Span, Token)]):
-      StringSlab[In with Token] = slab.removeLayer[Token].addLayer[Token](posTags)
+  override def addPosTags[In <: Token](slab: StringSlate, posTags: TraversableOnce[(Span, Token)]): StringSlate =
+    slab.removeLayer[Token].addLayer[Token](posTags)
 
   override def createPosTag(tag: String, token: Token): Token = token.copy(pos=Option(tag))
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
@@ -9,11 +9,11 @@ import org.sparkle.typesystem.basic.Sentence
 object SparkleSentenceOps extends SentenceOps[Sentence] {
   override def createSentence(): Sentence = Sentence()
 
-  override def selectAllSentences[In <: Sentence](slab: StringSlate): TraversableOnce[(Span, Sentence)] =
-    slab.iterator[Sentence]
+  override def selectAllSentences[In <: Sentence](slate: StringSlate): TraversableOnce[(Span, Sentence)] =
+    slate.iterator[Sentence]
 
-  override def selectSentences[In <: Sentence](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
-    slab.covered[Sentence](coveringSpan)
+  override def selectSentences[In <: Sentence](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
+    slate.covered[Sentence](coveringSpan)
 
   override def addSentences(slate: StringSlate, sentences: TraversableOnce[(Span, Sentence)]): StringSlate = slate.addLayer[Sentence](sentences)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
@@ -1,7 +1,7 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.Sentence
 import org.sparkle.slate._
+import org.sparkle.typesystem.basic.Sentence
 
 /**
   * Created by leebecker on 2/5/16.

--- a/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparkleSentenceOps.scala
@@ -1,20 +1,19 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.{StringSlab, Sentence}
-import epic.trees.Span
+import epic.slab.Sentence
+import org.sparkle.slate._
 
 /**
   * Created by leebecker on 2/5/16.
   */
-object SparkleSentenceOps extends SentenceOps[epic.slab.Sentence] {
+object SparkleSentenceOps extends SentenceOps[Sentence] {
   override def createSentence(): Sentence = Sentence()
 
-  override def selectAllSentences[In <: Sentence](slab: StringSlab[In]): TraversableOnce[(Span, Sentence)] =
+  override def selectAllSentences[In <: Sentence](slab: StringSlate): TraversableOnce[(Span, Sentence)] =
     slab.iterator[Sentence]
 
-  override def selectSentences[In <: Sentence](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
+  override def selectSentences[In <: Sentence](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Sentence)] =
     slab.covered[Sentence](coveringSpan)
 
-  override def addSentences[In](slab: StringSlab[In], sentences: TraversableOnce[(Span, Sentence)]):
-      StringSlab[In with Sentence] = slab.addLayer[Sentence](sentences)
+  override def addSentences(slate: StringSlate, sentences: TraversableOnce[(Span, Sentence)]): StringSlate = slate.addLayer[Sentence](sentences)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/SparkleTokenOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/SparkleTokenOps.scala
@@ -1,7 +1,6 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.StringSlab
-import epic.trees.Span
+import org.sparkle.slate._
 import org.sparkle.typesystem.basic.Token
 
 /**
@@ -10,11 +9,11 @@ import org.sparkle.typesystem.basic.Token
 object SparkleTokenOps extends TokenOps[Token]{
   override def create(text: String): Token = Token(text)
 
-  override def selectAllTokens[In <: Token](slab: StringSlab[In]): TraversableOnce[(Span, Token)] = slab.iterator[Token]
+  override def selectAllTokens[In <: Token](slate: StringSlate): TraversableOnce[(Span, Token)] = slate.iterator[Token]
 
-  override def selectTokens[In <: Token](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, Token)] =
-    slab.covered[Token](coveringSpan)
+  override def selectTokens[In <: Token](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, Token)] =
+    slate.covered[Token](coveringSpan)
 
-  override def addTokens[In](slab: StringSlab[In], tokens: TraversableOnce[(Span, Token)]):
-      StringSlab[In with Token] = slab.addLayer[Token](tokens)
+  override def addTokens(slate: StringSlate, tokens: TraversableOnce[(Span, Token)]):
+      StringSlate = slate.addLayer[Token](tokens)
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/TokenOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/TokenOps.scala
@@ -9,9 +9,9 @@ trait TokenOps[TOKEN_TYPE] {
 
   def create(text: String): TOKEN_TYPE
 
-  def selectTokens[In <: TOKEN_TYPE](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, TOKEN_TYPE)]
+  def selectTokens[In <: TOKEN_TYPE](slate: StringSlate, coveringSpan: Span): TraversableOnce[(Span, TOKEN_TYPE)]
 
-  def selectAllTokens[In <: TOKEN_TYPE](slab: StringSlate): TraversableOnce[(Span, TOKEN_TYPE)]
+  def selectAllTokens[In <: TOKEN_TYPE](slate: StringSlate): TraversableOnce[(Span, TOKEN_TYPE)]
 
-  def addTokens(slab: StringSlate, tokens: TraversableOnce[(Span, TOKEN_TYPE)]): StringSlate
+  def addTokens(slate: StringSlate, tokens: TraversableOnce[(Span, TOKEN_TYPE)]): StringSlate
 }

--- a/src/main/scala/org/sparkle/typesystem/ops/TokenOps.scala
+++ b/src/main/scala/org/sparkle/typesystem/ops/TokenOps.scala
@@ -1,7 +1,6 @@
 package org.sparkle.typesystem.ops
 
-import epic.slab.StringSlab
-import epic.trees.Span
+import org.sparkle.slate._
 
 /**
   * Created by leebecker on 2/5/16.
@@ -10,9 +9,9 @@ trait TokenOps[TOKEN_TYPE] {
 
   def create(text: String): TOKEN_TYPE
 
-  def selectTokens[In <: TOKEN_TYPE](slab: StringSlab[In], coveringSpan: Span): TraversableOnce[(Span, TOKEN_TYPE)]
+  def selectTokens[In <: TOKEN_TYPE](slab: StringSlate, coveringSpan: Span): TraversableOnce[(Span, TOKEN_TYPE)]
 
-  def selectAllTokens[In <: TOKEN_TYPE](slab: StringSlab[In]): TraversableOnce[(Span, TOKEN_TYPE)]
+  def selectAllTokens[In <: TOKEN_TYPE](slab: StringSlate): TraversableOnce[(Span, TOKEN_TYPE)]
 
-  def addTokens[In](slab: StringSlab[In], tokens: TraversableOnce[(Span, TOKEN_TYPE)]): StringSlab[In with TOKEN_TYPE]
+  def addTokens(slab: StringSlate, tokens: TraversableOnce[(Span, TOKEN_TYPE)]): StringSlate
 }

--- a/src/main/scala/org/sparkle/typesystem/syntax/dependency/DependencyGraph.scala
+++ b/src/main/scala/org/sparkle/typesystem/syntax/dependency/DependencyGraph.scala
@@ -1,15 +1,40 @@
 package org.sparkle.typesystem.syntax.dependency
 
 import epic.slab.Sentence
-import epic.trees.Span
+import org.sparkle.slate.Span
 import org.sparkle.typesystem.basic.{Token}
 
 import scala.collection.mutable
+import scala.collection.JavaConverters._
+import collection.JavaConversions._
+
 
 
 /**
   * Created by leebecker on 1/8/16.
   */
+
+case class SparkleToken(word: Option[String])
+
+case class SparkleSentence(token: Seq[SparkleToken])
+
+case class SparkleDocument(sentence: Seq[SparkleSentence])
+
+object Quick {
+  def convertSparkleSentence(sentenceTokens: java.util.List[java.util.List[String]]) = {
+    new SparkleDocument(
+      sentence=sentenceTokens.seq.map(tokens =>
+        new SparkleSentence(token=tokens.seq.map(token => new SparkleToken(word=Some(token))))
+      )
+    )
+  }
+
+
+
+}
+
+
+
 
 trait DependencyNode {
   val token: Option[Token]

--- a/src/main/scala/org/sparkle/typesystem/syntax/dependency/DependencyGraph.scala
+++ b/src/main/scala/org/sparkle/typesystem/syntax/dependency/DependencyGraph.scala
@@ -1,8 +1,7 @@
 package org.sparkle.typesystem.syntax.dependency
 
-import epic.slab.Sentence
 import org.sparkle.slate.Span
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.{Sentence, Token}
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._

--- a/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
+++ b/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
@@ -1,8 +1,8 @@
 package org.sparkle.clearnlp
 
-import epic.trees.Span
 import org.scalatest.FunSuite
-import epic.slab._
+import org.sparkle.slate._
+import epic.slab.Sentence
 import org.sparkle.typesystem.basic.Token
 import org.sparkle.typesystem.syntax.dependency._
 
@@ -11,13 +11,13 @@ class ClearNlpTest extends FunSuite {
   // =========
   // Analyzers
   // =========
-  val stringBegin = (slab: StringSlab[Span]) => slab
+  val stringBegin = (slab: StringSlate) => slab
 
   test("ClearNLP standalone sentence segmentation test") {
 
     val pipeline = new SentenceSegmenter()
 
-    val slab = pipeline(Slab( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
+    val slab = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
     val sentences = slab.iterator[Sentence].toList
     assert(sentences.map { case (span, _) => slab.spanned(span) } === List(
       """This is sentence one.""",
@@ -31,14 +31,14 @@ class ClearNlpTest extends FunSuite {
   // =========
   test("ClearNLP sentence segmentation and tokenization test") {
 
-    val sentenceSegmenter: StringAnalysisFunction[Any, Sentence] = ClearNlpTokenization.sentenceSegmenter()
-    val tokenizer: StringAnalysisFunction[Sentence, Token] = ClearNlpTokenization.tokenizer()
-    val posTagger: StringAnalysisFunction[Sentence with Token, Token] = PosTagger.sparkleTypesPosTagger()
-    val mpAnalyzer: StringAnalysisFunction[Sentence with Token, Token] = MpAnalyzer
-    val depParser: StringAnalysisFunction[Sentence with Token, DependencyNode with DependencyRelation] = DependencyParser
+    val sentenceSegmenter: StringAnalysisFunction = ClearNlpTokenization.sentenceSegmenter()
+    val tokenizer: StringAnalysisFunction = ClearNlpTokenization.tokenizer()
+    val posTagger: StringAnalysisFunction = PosTagger.sparkleTypesPosTagger()
+    val mpAnalyzer: StringAnalysisFunction = MpAnalyzer
+    val depParser: StringAnalysisFunction = DependencyParser
 
     val pipeline = sentenceSegmenter andThen tokenizer andThen posTagger andThen MpAnalyzer andThen DependencyParser
-    val slab = pipeline(Slab( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
+    val slab = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
     val sentences = slab.iterator[Sentence].toList
     assert(sentences.map{case (span, _) => slab.spanned(span)} === List(
       """This is sentence one.""",

--- a/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
+++ b/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
@@ -10,15 +10,15 @@ class ClearNlpTest extends FunSuite {
   // =========
   // Analyzers
   // =========
-  val stringBegin = (slab: StringSlate) => slab
+  val stringBegin = (slate: StringSlate) => slate
 
   test("ClearNLP standalone sentence segmentation test") {
 
     val pipeline = new SentenceSegmenter()
 
-    val slab = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
-    val sentences = slab.iterator[Sentence].toList
-    assert(sentences.map { case (span, _) => slab.spanned(span) } === List(
+    val slate = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
+    val sentences = slate.iterator[Sentence].toList
+    assert(sentences.map { case (span, _) => slate.spanned(span) } === List(
       """This is sentence one.""",
       """Do you like sentence 2?""",
       """Mr. and Dr. Takahashi want to leave!""",
@@ -37,9 +37,9 @@ class ClearNlpTest extends FunSuite {
     val depParser: StringAnalysisFunction = DependencyParser
 
     val pipeline = sentenceSegmenter andThen tokenizer andThen posTagger andThen MpAnalyzer andThen DependencyParser
-    val slab = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
-    val sentences = slab.iterator[Sentence].toList
-    assert(sentences.map{case (span, _) => slab.spanned(span)} === List(
+    val slate = pipeline(Slate( """This is sentence one.  Do you like sentence 2?  Mr. and Dr. Takahashi want to leave!  Go now!"""))
+    val sentences = slate.iterator[Sentence].toList
+    assert(sentences.map{case (span, _) => slate.spanned(span)} === List(
       """This is sentence one.""",
       """Do you like sentence 2?""",
       """Mr. and Dr. Takahashi want to leave!""",
@@ -47,18 +47,18 @@ class ClearNlpTest extends FunSuite {
     ))
 
     val spanAnnotationToText = (spanAnnotationPair: Tuple2[Span, Any]) => spanAnnotationPair match {
-      case (span, _) => slab.spanned(span)
+      case (span, _) => slate.spanned(span)
     }
 
-    val tokensInSentence0 = slab.covered[Token](sentences.head._1).toList
+    val tokensInSentence0 = slate.covered[Token](sentences.head._1).toList
     assert(tokensInSentence0.map(spanAnnotationToText) === List("This", "is", "sentence", "one", "."))
 
-    val tokensBeforeSentence1 = slab.preceding[Token](sentences(1)._1).toList
+    val tokensBeforeSentence1 = slate.preceding[Token](sentences(1)._1).toList
     assert(tokensBeforeSentence1.map(spanAnnotationToText) === tokensInSentence0.map(spanAnnotationToText).reverse)
 
-    val tokens = slab.iterator[Token].toList
-    val tokensAfterToken18 = slab.following[Token](tokens(18)._1).toList
-    val tokensInSentence3 = slab.covered[Token](sentences(3)._1).toList
+    val tokens = slate.iterator[Token].toList
+    val tokensAfterToken18 = slate.following[Token](tokens(18)._1).toList
+    val tokensInSentence3 = slate.covered[Token](sentences(3)._1).toList
     assert(tokensAfterToken18.map(spanAnnotationToText) === tokensInSentence3.map(spanAnnotationToText))
 
     val posTagsInSentence0 = tokensInSentence0.map{ case (span, token) => token.pos.get }
@@ -67,7 +67,7 @@ class ClearNlpTest extends FunSuite {
     val lemmasInSentence0 = tokensInSentence0.map{ case (span, token) => token.lemma.get }
     assert(lemmasInSentence0 === List("this", "be", "sentence", "#crd#", "."))
 
-    val depRelationsInSentence0 = slab.covered[DependencyRelation](sentences.head._1)
+    val depRelationsInSentence0 = slate.covered[DependencyRelation](sentences.head._1)
     val triplesInSentence = depRelationsInSentence0.map{case (span, rel) => DependencyUtils.extractTriple(rel)}
     assert(triplesInSentence === List(
       ("attr", "This", "is"),
@@ -77,7 +77,7 @@ class ClearNlpTest extends FunSuite {
       ("nsubj", "sentence", "one"))
     )
 
-    val depNodesInSentence0 = slab.covered[DependencyNode](sentences.head._1)
+    val depNodesInSentence0 = slate.covered[DependencyNode](sentences.head._1)
     val triplesInSentence0 = depNodesInSentence0.flatMap(x => x match {
       case (s: Span, d: RootDependencyNode) => None
       case (s: Span, d: TokenDependencyNode) => Some(DependencyUtils.extractTriple(d))

--- a/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
+++ b/src/test/scala/org/sparkle/clearnlp/ClearNlpTest.scala
@@ -2,8 +2,7 @@ package org.sparkle.clearnlp
 
 import org.scalatest.FunSuite
 import org.sparkle.slate._
-import epic.slab.Sentence
-import org.sparkle.typesystem.basic.Token
+import org.sparkle.typesystem.basic.{Sentence,Token}
 import org.sparkle.typesystem.syntax.dependency._
 
 class ClearNlpTest extends FunSuite {

--- a/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
+++ b/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
@@ -9,13 +9,13 @@ class OpenNlpTest extends FunSuite {
   // =========
   // Analyzers
   // =========
-  val stringBegin = (slab: StringSlate) => slab
+  val stringBegin = (slate: StringSlate) => slate
 
   test("OpenNlp sentence segmentation test") {
 
     val pipeline: StringAnalysisFunction = OpenNlpSentenceSegmenter.sentenceSegmenter()
 
-    val slab = pipeline(Slate(
+    val slate = pipeline(Slate(
       """
 
         This is sentence one.
@@ -23,11 +23,11 @@ class OpenNlpTest extends FunSuite {
 
       """))
 
-    for ((span, sent) <- slab.iterator[Sentence]) {
+    for ((span, sent) <- slate.iterator[Sentence]) {
 
     }
-    val sentences = slab.iterator[Sentence].toList
-    assert(sentences.map { case (span, _) => slab.spanned(span) } === List(
+    val sentences = slate.iterator[Sentence].toList
+    assert(sentences.map { case (span, _) => slate.spanned(span) } === List(
       """This is sentence one.""",
       """Do you like sentence two?""",
       """Mr. and Dr. Takahashi want to leave!""",

--- a/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
+++ b/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
@@ -1,22 +1,22 @@
 package org.sparkle.opennlp
 
-import epic.slab._
-import epic.trees.Span
+import org.sparkle.slate._
 import org.scalatest.FunSuite
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.Token
+import epic.slab.Sentence
 
 class OpenNlpTest extends FunSuite {
 
   // =========
   // Analyzers
   // =========
-  val stringBegin = (slab: StringSlab[Span]) => slab
+  val stringBegin = (slab: StringSlate) => slab
 
   test("OpenNlp sentence segmentation test") {
 
-    val pipeline: StringAnalysisFunction[Any, Sentence] = OpenNlpSentenceSegmenter.sentenceSegmenter()
+    val pipeline: StringAnalysisFunction = OpenNlpSentenceSegmenter.sentenceSegmenter()
 
-    val slab = pipeline(Slab(
+    val slab = pipeline(Slate(
       """
 
         This is sentence one.

--- a/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
+++ b/src/test/scala/org/sparkle/opennlp/OpenNlpTest.scala
@@ -2,8 +2,7 @@ package org.sparkle.opennlp
 
 import org.sparkle.slate._
 import org.scalatest.FunSuite
-import org.sparkle.typesystem.basic.Token
-import epic.slab.Sentence
+import org.sparkle.typesystem.basic.{Sentence,Token}
 
 class OpenNlpTest extends FunSuite {
 

--- a/src/test/scala/org/sparkle/spark/SparkTest.scala
+++ b/src/test/scala/org/sparkle/spark/SparkTest.scala
@@ -1,7 +1,6 @@
 package org.sparkle.spark
 
 import org.scalatest._
-import epic.slab.Sentence
 import org.sparkle.slate._
 import org.sparkle.clearnlp._
 import org.sparkle.preprocess.RegexSplitTokenizer

--- a/src/test/scala/org/sparkle/spark/SparkTest.scala
+++ b/src/test/scala/org/sparkle/spark/SparkTest.scala
@@ -1,17 +1,18 @@
 package org.sparkle.spark
 
 import org.scalatest._
-import epic.slab._
+import epic.slab.Sentence
+import org.sparkle.slate._
 import org.sparkle.clearnlp._
 import org.sparkle.preprocess.RegexSplitTokenizer
-import org.sparkle.typesystem.basic.{Token}
+import org.sparkle.typesystem.basic.Token
 
 import org.apache.spark.{SparkConf, SparkContext}
 
 object SparkTestUtils {
-  val sentenceSegmenterAndTokenizer: StringAnalysisFunction[Any, Sentence with Token] = SentenceSegmenterAndTokenizer
-  val posTagger: StringAnalysisFunction[Sentence with Token, Token] = PosTagger.sparkleTypesPosTagger()
-  val mpAnalyzer: StringAnalysisFunction[Sentence with Token, Token] = MpAnalyzer
+  val sentenceSegmenterAndTokenizer: StringAnalysisFunction = SentenceSegmenterAndTokenizer
+  val posTagger: StringAnalysisFunction = PosTagger.sparkleTypesPosTagger()
+  val mpAnalyzer: StringAnalysisFunction = MpAnalyzer
 
   val pipeline = sentenceSegmenterAndTokenizer andThen posTagger andThen mpAnalyzer
   //def opennlpPipeline(s: StringSlab[Any]) = org.sparkle.opennlp.SentenceSegmenter.apply(s)
@@ -32,9 +33,9 @@ class SparkTest extends FunSuite with Matchers {
 
   test("SparkWithRegexTokenizer") {
     val slabs = Seq(
-        Slab("""Words are fun to count.  Counting words is what we Mr. Jones O.K. do."""),
-        Slab("""Whether it be one word, two words or more, we our word count will score."""),
-        Slab("""Wording this last set of words to count is wordy.""")
+        Slate("""Words are fun to count.  Counting words is what we Mr. Jones O.K. do."""),
+        Slate("""Whether it be one word, two words or more, we our word count will score."""),
+        Slate("""Wording this last set of words to count is wordy.""")
       )
       val slabRdd = sc.parallelize(slabs).map(slab => SparkTestUtils.regexPipeline(slab))
       val sentences = slabRdd.map {slab => (slab, slab.iterator[Token].toSeq)}.flatMap{case(slab, tokens) => tokens.map(t => slab.spanned(t._1))}
@@ -60,13 +61,13 @@ class SparkTest extends FunSuite with Matchers {
 
   test("TokenCountsWithSpark") {
     val slabs = Seq(
-      Slab("""Words are fun to count.  Counting words is what we do."""),
-      Slab("""Whether it be one word, two words or more, we our word count will score."""),
-      Slab("""Wording this last set of words to count is wordy.""")
+      Slate("""Words are fun to count.  Counting words is what we do."""),
+      Slate("""Whether it be one word, two words or more, we our word count will score."""),
+      Slate("""Wording this last set of words to count is wordy.""")
     )
 
 
-    val mySlab0 = Slab("""Words are fun to count.  Counting words is what we do.""")
+    val mySlab0 = Slate("""Words are fun to count.  Counting words is what we do.""")
     val mySlab1 = SparkTestUtils.sentenceSegmenterAndTokenizer(mySlab0)
     val mySlab2 = PosTagger.sparkleTypesPosTagger()(mySlab1)
     val mySlab3 = MpAnalyzer(mySlab2)

--- a/src/test/scala/org/sparkle/spark/SparkTest.scala
+++ b/src/test/scala/org/sparkle/spark/SparkTest.scala
@@ -14,7 +14,7 @@ object SparkTestUtils {
   val mpAnalyzer: StringAnalysisFunction = MpAnalyzer
 
   val pipeline = sentenceSegmenterAndTokenizer andThen posTagger andThen mpAnalyzer
-  //def opennlpPipeline(s: StringSlab[Any]) = org.sparkle.opennlp.SentenceSegmenter.apply(s)
+  //def opennlpPipeline(s: StringSlate[Any]) = org.sparkle.opennlp.SentenceSegmenter.apply(s)
   val regexPipeline = new RegexSplitTokenizer("""[\W]+\s*""")
 }
 
@@ -31,13 +31,13 @@ class SparkTest extends FunSuite with Matchers {
   //import sqlContext.implicits._
 
   test("SparkWithRegexTokenizer") {
-    val slabs = Seq(
+    val slates = Seq(
         Slate("""Words are fun to count.  Counting words is what we Mr. Jones O.K. do."""),
         Slate("""Whether it be one word, two words or more, we our word count will score."""),
         Slate("""Wording this last set of words to count is wordy.""")
       )
-      val slabRdd = sc.parallelize(slabs).map(slab => SparkTestUtils.regexPipeline(slab))
-      val sentences = slabRdd.map {slab => (slab, slab.iterator[Token].toSeq)}.flatMap{case(slab, tokens) => tokens.map(t => slab.spanned(t._1))}
+      val slateRDD = sc.parallelize(slates).map(slate => SparkTestUtils.regexPipeline(slate))
+      val sentences = slateRDD.map {slate => (slate, slate.iterator[Token].toSeq)}.flatMap{case(slate, tokens) => tokens.map(t => slate.spanned(t._1))}
       sentences.foreach(println("*", _))
 
   }
@@ -46,34 +46,33 @@ class SparkTest extends FunSuite with Matchers {
   test("SparkWithOpenNlp") {
     //This test will fail if Spark is running multithreaded.
 
-     val slabs = Seq(
-      Slab("""Words are fun to count.  Counting words is what we do."""),
-      Slab("""Whether it be one word, two words or more, we our word count will score."""),
-      Slab("""Wording this last set of words to count is wordy.""")
+     val slates = Seq(
+      Slate("""Words are fun to count.  Counting words is what we do."""),
+      Slate("""Whether it be one word, two words or more, we our word count will score."""),
+      Slate("""Wording this last set of words to count is wordy.""")
     )
-    val slabRdd = sc.parallelize(slabs).map(SparkTestUtils.opennlpPipeline)
-    val sentences = slabRdd.map {slab => (slab, slab.iterator[Sentence].toSeq)}.flatMap{case(slab, sentences) => sentences.map(s => slab.spanned(s._1))}
+    val slateRDD = sc.parallelize(slates).map(SparkTestUtils.opennlpPipeline)
+    val sentences = slateRDD.map {slate => (slate, slate.iterator[Sentence].toSeq)}.flatMap{case(slate, sentences) => sentences.map(s => slate.spanned(s._1))}
     sentences.foreach(println("*", _))
 
   }
   */
 
   test("TokenCountsWithSpark") {
-    val slabs = Seq(
+    val slates = Seq(
       Slate("""Words are fun to count.  Counting words is what we do."""),
       Slate("""Whether it be one word, two words or more, we our word count will score."""),
       Slate("""Wording this last set of words to count is wordy.""")
     )
 
 
-    val mySlab0 = Slate("""Words are fun to count.  Counting words is what we do.""")
-    val mySlab1 = SparkTestUtils.sentenceSegmenterAndTokenizer(mySlab0)
-    val mySlab2 = PosTagger.sparkleTypesPosTagger()(mySlab1)
-    val mySlab3 = MpAnalyzer(mySlab2)
+    val mySlate0 = Slate("""Words are fun to count.  Counting words is what we do.""")
+    val mySlate1 = SparkTestUtils.sentenceSegmenterAndTokenizer(mySlate0)
+    val mySlate2 = PosTagger.sparkleTypesPosTagger()(mySlate1)
+    val mySlate3 = MpAnalyzer(mySlate2)
 
-    val slabRdd = sc.parallelize(slabs).map(slab => SparkTestUtils.pipeline(slab))
-
-    val tokensRdd = slabRdd.map { slab => slab.iterator[Token].toSeq}.flatMap(tokens => tokens)
+    val slateRDD = sc.parallelize(slates).map(slate => SparkTestUtils.pipeline(slate))
+    val tokensRdd = slateRDD.map { slate => slate.iterator[Token].toSeq}.flatMap(tokens => tokens)
 
     val wordCountsRdd = tokensRdd.map{ case (_, token) => (token.token, 1) }.reduceByKey(_ + _)
     val wordCounts = wordCountsRdd.collectAsMap()


### PR DESCRIPTION
Code now uses a _slate_ structure instead of a _slab_ structure.  This grants more flexibility in working with Spark at the expense of having compile time checking of functions.