### PR TITLE
Slate extractor tf map partitions

### DIFF
--- a/core/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
+++ b/core/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
@@ -2,7 +2,7 @@ package org.sparkle.slate.spark
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.Transformer
-import org.apache.spark.ml.param.{Param, ParamMap}
+import org.apache.spark.ml.param.{BooleanParam, Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.ScalaReflection
@@ -15,16 +15,31 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
 
+/**
+  *  A [[org.apache.spark.sql.DataFrame DataFrame]] [[org.apache.spark.ml.Transformer transformer]]
+  *  which runs a [[org.sparkle.slate.Slate String Slate]] pipeline function
+  *  on a text column and subsequently extracts values using a collection of [[org.sparkle.slate.spark.StringSlateExtractor StringSlateExtractors]].
+  *
+  *  This is useful for running NLP pipelines consisting of [[org.sparkle.slate.AnalysisFunction Slate AnalysisFunctions]] to annotate text
+  *  and to extract features for training machine learning algorithms or other analyses.
+  * @tparam T1 Type returned by extractors.  The type must be serializable and compatible with Spark DataFrame [[org.apache.spark.sql.types.DataType DataTypes]].  Extracted values
+  *            are homogeneous. For heterogeneous extraction use [[org.sparkle.slate.spark.SlateExtractorTransformer2 SlateExtractorTransformer2]] or
+  *            [[org.sparkle.slate.spark.SlateExtractorTransformer3 SlateExtractorTransformer3]].
+  */
 class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) extends Transformer {
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor"))
 
+  val slateIdentityFunction = (slate: StringSlate) => slate
+
   val slatePipelineFunc: Param[(StringSlate)=>(StringSlate)] = new Param(this, "slatePipelineFunc",
-    "A function which accepts a slate structure and returns a new one. " +
-    "Most often this will wrap up a StringAnalysisFunction, but it needn't be.")
+    """A function which accepts a slate structure and returns a new one.
+      |Most often this will wrap up a StringAnalysisFunction, but it needn't be.
+      |By default this is set to an identity function""".stripMargin)
 
   def getSlatePipelineFunc: (StringSlate)=>(StringSlate) = $(slatePipelineFunc)
 
   def setSlatePipelineFunc(value: (StringSlate)=>(StringSlate)): this.type = set(slatePipelineFunc, value)
+  setDefault(slatePipelineFunc->slateIdentityFunction)
 
   val textCol: Param[String] = new Param(this, "textCol", "name of column containing text to be analyzed")
 
@@ -40,6 +55,30 @@ class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) e
   def getExtractors1: Seq[ExtractorsType1] = $(extractors1)
 
   def setExtractors1(value: Seq[ExtractorsType1]): this.type = set("extractors1", value)
+
+  val mapPartitionsOnPipeline: BooleanParam = new BooleanParam(this, "mapPartitionsOnPipeline",
+    """
+      Turning this on will run the pipeline function separately on each partition instead of
+      on each element.  This is especially useful when the pipeline has a large initialization
+      cost.  This is turned on by default.
+    """.stripMargin)(true)
+
+  def getMapPartitionsOnPipeline: Boolean = $(mapPartitionsOnPipeline)
+
+  def setMapPartitionsOnPipeline(value: Boolean): this.type = set("mapPartitionsOnPipeline", value)
+  setDefault(mapPartitionsOnPipeline -> true)
+
+  val mapPartitionsOnExtractors: BooleanParam = new BooleanParam(this, "mapPartitionsOnExtractors",
+    """
+      Turning this on will run the extractor functions separately on each partition instead of
+      on each element.  This is especially useful when extractor have a large initialization
+      cost.  This is turned off by default.
+    """.stripMargin)
+
+  def getMapPartitionsOnExtractors: Boolean = $(mapPartitionsOnExtractors)
+
+  def setMapPartitionsOnExtractors(value: Boolean): this.type = set("mapPartitionsOnExtractors", value)
+  setDefault(mapPartitionsOnPipeline -> false)
 
   def makeZip(s: Seq[RDD[_]]): RDD[Seq[_]] = {
     if (s.length == 1)
@@ -72,12 +111,27 @@ class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) e
 
 
   def extractFromText(textRdd: RDD[String]): RDD[Seq[_]] = {
+    /*
     val slateInRdd = textRdd.map(Slate(_))
     // Run the pipeline
     val slateOutRdd = slateInRdd.map(getSlatePipelineFunc)
+    */
+
+    val slateOutRdd = if (getMapPartitionsOnPipeline) {
+      textRdd.mapPartitionsWithIndex((idx, iterator) => {
+        println(s"Running pipeline on partition $idx")
+        iterator.map(text => getSlatePipelineFunc(Slate(text)))
+      })
+    } else {
+      textRdd.map(text=>getSlatePipelineFunc(Slate(text)))
+    }
 
     // Run each of the extractors
-    val extractedColumnRDDs = for ((extractorName, extractor) <- getExtractors) yield slateOutRdd.map(extractor(_))
+    val extractedColumnRDDs = if (getMapPartitionsOnExtractors) {
+      for ((extractorName, extractor) <- getExtractors) yield slateOutRdd.mapPartitions(iterator => iterator.map(extractor(_)))
+    } else {
+      for ((extractorName, extractor) <- getExtractors) yield slateOutRdd.map(extractor(_))
+    }
     makeZip(extractedColumnRDDs)
   }
 
@@ -87,6 +141,13 @@ class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) e
   override def transformSchema(schemaIn: StructType): StructType = StructType(schemaIn ++ getExtractorSchemas)
 }
 
+/**
+  * Two type version of [[org.sparkle.slate.spark.SlateExtractorTransformer SlateExtractorTransformer]].  Use this instead of the one type version if
+  * your extraction types are heterogeneous. For example the extraction flow produces integers, doubles and complex structs.
+  *
+  * @tparam T1 Type returned by first set of extractors.  The type must be serializable and compatible with Spark DataFrame [[org.apache.spark.sql.types.DataType DataTypes]].
+  * @tparam T2 Type returned by second set of extractors. Refer to T1 for type constraints.
+  */
 class SlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](override val uid: String)
   extends SlateExtractorTransformer[T1] {
 
@@ -111,6 +172,14 @@ class SlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](overr
   }
 }
 
+/**
+  * Three type version of [[org.sparkle.slate.spark.SlateExtractorTransformer SlateExtractorTransformer]].  Use this instead of the one type version if
+  * your extraction types are heterogeneous. For example the extraction flow produces integers, doubles and complex structs.
+  *
+  * @tparam T1 Type returned by first set of extractors.  The type must be serializable and compatible with Spark DataFrame [[org.apache.spark.sql.types.DataType DataTypes]].
+  * @tparam T2 Type returned by second set of extractors. Refer to T1 for type constraints.
+  * @tparam T3 Type returned by the third set of extractors.  Refer to T1 for type constraints.
+  */
  class SlateExtractorTransformer3[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag, T3:TypeTag:ClassTag](override val uid: String)
   extends SlateExtractorTransformer2[T1,T2] {
 

--- a/core/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
+++ b/core/src/main/scala/org/sparkle/slate/spark/SlateExtractorTransformer.scala
@@ -69,9 +69,8 @@ class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) e
 
   val mapPartitionsOnPipeline: BooleanParam = new BooleanParam(this, "mapPartitionsOnPipeline",
     """
-      Turning this on will run the pipeline function separately on each partition instead of
-      on each element.  This is especially useful when the pipeline has a large initialization
-      cost.  This is turned on by default.
+      |Turning this on will run the pipeline function separately on each partition instead of
+      |on each element.  Useful when pipeline has large initialization cost.
     """.stripMargin)
 
   def getMapPartitionsOnPipeline: Boolean = $(mapPartitionsOnPipeline)
@@ -81,9 +80,9 @@ class SlateExtractorTransformer[T1:TypeTag:ClassTag](override val uid: String) e
 
   val mapPartitionsOnExtractors: BooleanParam = new BooleanParam(this, "mapPartitionsOnExtractors",
     """
-      Turning this on will run the extractor functions separately on each partition instead of
-      on each element.  This is especially useful when extractor have a large initialization
-      cost.  This is turned off by default.
+      |Turning this on will run the extractor functions separately on each partition instead of
+      |on each element.  This is especially useful when extractors have large initialization
+      |cost.
     """.stripMargin)
 
   def getMapPartitionsOnExtractors: Boolean = $(mapPartitionsOnExtractors)
@@ -156,16 +155,17 @@ class SlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](overr
 
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor2"))
 
-  type ExtractorsType2 = (String, StringSlateExtractor[T2])
+  type ExtractorsType2 = StringSlateExtractor[T2]
 
-  val extractors2: Param[Seq[ExtractorsType2]] = new Param(this, "extractors2",
+  val extractors2: Param[Map[String, ExtractorsType2]] = new Param(this, "extractors2",
     "Map of outputColumns and their StringSlateExtractor function objects")
 
-  def getExtractors2: Seq[ExtractorsType2] = $(extractors2)
+  def getExtractors2: Map[String, ExtractorsType2] = $(extractors2)
 
-  def setExtractors2(value: Seq[ExtractorsType2]): this.type = set("extractors2", value)
+  def setExtractors2(value: Map[String, ExtractorsType2]): this.type = set("extractors2", value)
+  setDefault(extractors2-> Map())
 
-  override def getExtractors = super.getExtractors ++ getExtractors2
+  override def getExtractors = super.getExtractors ++ getExtractors2.toSeq
 
   override def getExtractorSchemas = {
     val dataType2 = ScalaReflection.schemaFor[T2].dataType
@@ -188,14 +188,16 @@ class SlateExtractorTransformer2[T1:TypeTag:ClassTag, T2:TypeTag:ClassTag](overr
 
   def this() = this(Identifiable.randomUID("sparkler_slate_extractor3"))
 
-  type ExtractorsType3 = (String, StringSlateExtractor[T3])
 
-  val extractors3: Param[Seq[ExtractorsType3]] = new Param(this, "extractors3",
+  type ExtractorsType3 = StringSlateExtractor[T3]
+
+  val extractors3: Param[Map[String, ExtractorsType3]] = new Param(this, "extractors3",
     "Map of outputColumns and their StringSlateExtractor function objects")
 
-  def getExtractors3: Seq[ExtractorsType3] = $(extractors3)
+  def getExtractors3: Map[String, ExtractorsType3] = $(extractors3)
 
-  def setExtractors3(value: Seq[ExtractorsType3]): this.type = set("extractors3", value)
+  def setExtractors3(value: Map[String, ExtractorsType3]): this.type = set("extractors3", value)
+  setDefault(extractors3-> Map())
 
   override def getExtractors = super.getExtractors ++ getExtractors3
 


### PR DESCRIPTION
To allow for the possibility of expensive initialization of pipelines, this transformer now has parameters
to enable mapping over partitions instead of elements.  This is especially helpful when the pipeline
requires loading large models or lexica as seen with a syntactical parser.